### PR TITLE
First implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/blocks-concurrent-subscriber
+/vendor

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
 # blocks-concurrent-batch-subscriber
+
+## Overview
+
+This is the first PR of `blocks-concurrent-subscriber`.
+It subscribes the progresses of jobs with `blocks concurrent batch board` of [magellan-blocks](https://www.magellanic-clouds.com/blocks/).
+When the progresses are notified, `blocks-concurrent-subscriber` updates the status of the job and inserts the logs on mysql.
+
+`blocks-concurrent-subscriber` access to `blocks-concurrent-batch-agent` to get subscriptions to pull messages.
+
+## Install
+
+```bash
+$ go get github.com/groovenauts/blocks-concurrent-subscriber
+```
+
+## Usage
+
+```bash
+$ blocks-concurrent-subscriber \
+  --project [Your GCP Project] \
+  --datasource [Datasource string to Your MySQL] \
+  --agent-root-ur [URL to your blocks-concurrent-batch-agent] \
+  --agent-token [Token of your blocks-concurrent-batch-agent]
+```
+
+### `--datasource`
+
+`datasource` must be a string to connect your MySQL database like this:
+
+```
+"user:password@/dbname"
+```
+
+See https://github.com/go-sql-driver/mysql#usage for more detail.
+
+### `--agent-root-ur`
+
+This is an URL to the blocks-concurrent-batch-agent you deploy to GAE.
+
+For example:
+
+```
+https://concurrent-batch-agent-dot-your-gcp-project.appspot.com
+```
+
+### `--agent-token`
+
+After you deploy blocks-concurrent-batch-agent, you can get tokens for authorization.
+See https://github.com/groovenauts/blocks-concurrent-batch-agent#get-token-on-browser for more detail.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ## Overview
 
-This is the first PR of `blocks-concurrent-subscriber`.
-It subscribes the progresses of jobs with `blocks concurrent batch board` of [magellan-blocks](https://www.magellanic-clouds.com/blocks/).
+`blocks-concurrent-subscriber` subscribes the progresses of jobs with `blocks concurrent batch board` of [magellan-blocks](https://www.magellanic-clouds.com/blocks/).
 When the progresses are notified, `blocks-concurrent-subscriber` updates the status of the job and inserts the logs on mysql.
 
 `blocks-concurrent-subscriber` access to `blocks-concurrent-batch-agent` to get subscriptions to pull messages.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ go get github.com/groovenauts/blocks-concurrent-subscriber
 $ blocks-concurrent-subscriber \
   --project [Your GCP Project] \
   --datasource [Datasource string to Your MySQL] \
-  --agent-root-ur [URL to your blocks-concurrent-batch-agent] \
+  --agent-root-url [URL to your blocks-concurrent-batch-agent] \
   --agent-token [Token of your blocks-concurrent-batch-agent]
 ```
 
@@ -33,7 +33,7 @@ $ blocks-concurrent-subscriber \
 
 See https://github.com/go-sql-driver/mysql#usage for more detail.
 
-### `--agent-root-ur`
+### `--agent-root-url`
 
 This is an URL to the blocks-concurrent-batch-agent you deploy to GAE.
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ When the progresses are notified, `blocks-concurrent-subscriber` updates the sta
 
 ## Install
 
-```bash
-$ go get github.com/groovenauts/blocks-concurrent-subscriber
-```
+Download the file from https://github.com/groovenauts/blocks-concurrent-subscriber/releases
+and put it somewhere on PATH.
 
 ## Usage
 

--- a/agent_client.go
+++ b/agent_client.go
@@ -9,15 +9,19 @@ import (
 	"golang.org/x/net/context"
 )
 
+type HttpRequester interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 type DefaultAgentClient struct{
-	httpClient   *http.Client
+	httpRequester HttpRequester
 	httpUrl      string
 	httpToken    string
 }
 
 func (ac *DefaultAgentClient) getSubscriptions(ctx context.Context) ([]*Subscription, error) {
-	if ac.httpClient == nil {
-		ac.httpClient = new(http.Client)
+	if ac.httpRequester == nil {
+		ac.httpRequester = new(http.Client)
 	}
 
 	req, err := http.NewRequest("GET", ac.httpUrl+"/pipelines/subscriptions", nil)
@@ -25,7 +29,7 @@ func (ac *DefaultAgentClient) getSubscriptions(ctx context.Context) ([]*Subscrip
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Bearer "+ac.httpToken)
-	resp, err := ac.httpClient.Do(req)
+	resp, err := ac.httpRequester.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/agent_client.go
+++ b/agent_client.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+type DefaultAgentClient struct{
+	httpClient   *http.Client
+	httpUrl      string
+	httpToken    string
+}
+
+func (ac *DefaultAgentClient) getSubscriptions(ctx context.Context) ([]*Subscription, error) {
+	if ac.httpClient == nil {
+		ac.httpClient = new(http.Client)
+	}
+
+	req, err := http.NewRequest("GET", ac.httpUrl+"/pipelines/subscriptions", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+ac.httpToken)
+	resp, err := ac.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var subscriptions []Subscription
+	err = json.Unmarshal(byteArray, &subscriptions)
+	if err != nil {
+		return nil, err
+	}
+	result := []*Subscription{}
+	for _, subscription := range subscriptions {
+		result = append(result, &subscription)
+	}
+	return result, nil
+}

--- a/agent_client.go
+++ b/agent_client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -34,6 +35,7 @@ func (ac *DefaultAgentClient) getSubscriptions(ctx context.Context) ([]*Subscrip
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("DefaultAgentClient.getSubscriptions()\n%v\n", string(byteArray))
 
 	var subscriptions []Subscription
 	err = json.Unmarshal(byteArray, &subscriptions)

--- a/agent_client_test.go
+++ b/agent_client_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/net/context"
+)
+
+type DummyHttp struct {}
+
+func (dh *DummyHttp) Do(req *http.Request) (*http.Response, error) {
+	resp := `[{"pipeline":"pipeline01","subscription":"pipeline01-progress-subscription"}]`
+	return &http.Response{
+		Body: ioutil.NopCloser(strings.NewReader(resp)),
+	}, nil
+}
+
+func TestGetSubscriptions(t *testing.T) {
+	ac := &DefaultAgentClient{
+		httpRequester: &DummyHttp{},
+		httpUrl: "http://somewhere",
+		httpToken: "DUMMY-TOKEN",
+	}
+	ctx := context.Background()
+	subscriptions, err := ac.getSubscriptions(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(subscriptions))
+	sub := subscriptions[0]
+	assert.Equal(t, "pipeline01", sub.Pipeline)
+	assert.Equal(t, "pipeline01-progress-subscription", sub.Name)
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,89 @@
+hash: f7118f106009f1497de7ca5032fbe39a3c97411702d90891b4495520a654e3eb
+updated: 2017-02-06T20:23:44.809903524+09:00
+imports:
+- name: cloud.google.com/go
+  version: 81b7822b1e798e8f17bf64b59512a5be4097e966
+  subpackages:
+  - compute/metadata
+  - iam
+  - internal
+  - pubsub
+  - pubsub/apiv1
+- name: github.com/go-sql-driver/mysql
+  version: 2e00b5cd70399450106cec6431c2e2ce3cae5034
+- name: github.com/golang/protobuf
+  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  subpackages:
+  - proto
+  - protoc-gen-go/descriptor
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/empty
+  - ptypes/timestamp
+- name: github.com/googleapis/gax-go
+  version: da06d194a00e19ce00d9011a13931c3f6f6887c7
+- name: github.com/urfave/cli
+  version: 347a9884a87374d000eec7e6445a34487c1f4a2b
+- name: golang.org/x/net
+  version: 69d4b8aa71caaaa75c3dfc11211d1be495abec7c
+  subpackages:
+  - context
+  - context/ctxhttp
+  - http2
+  - http2/hpack
+  - idna
+  - internal/timeseries
+  - lex/httplex
+  - trace
+- name: golang.org/x/oauth2
+  version: 314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
+- name: google.golang.org/api
+  version: b9d03e6e091e36f9a089515bc84cf14c2d199c4c
+  subpackages:
+  - googleapi/transport
+  - internal
+  - iterator
+  - option
+  - support/bundler
+  - transport
+- name: google.golang.org/appengine
+  version: 08a149cfaee099e6ce4be01c0113a78c85ee1dee
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/socket
+  - internal/urlfetch
+  - socket
+  - urlfetch
+- name: google.golang.org/genproto
+  version: b3e7c2fb04031add52c4817f53f43757ccbf9c18
+  subpackages:
+  - googleapis/api/annotations
+  - googleapis/iam/v1
+  - googleapis/pubsub/v1
+- name: google.golang.org/grpc
+  version: 50955793b0183f9de69bd78e2ec251cf20aab121
+  subpackages:
+  - codes
+  - credentials
+  - credentials/oauth
+  - grpclog
+  - internal
+  - metadata
+  - naming
+  - peer
+  - stats
+  - tap
+  - transport
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,13 @@
+package: github.com/groovenauts/blocks-concurrent-subscriber
+import:
+- package: cloud.google.com/go
+  subpackages:
+  - pubsub
+- package: github.com/go-sql-driver/mysql
+- package: github.com/urfave/cli
+- package: golang.org/x/net
+  subpackages:
+  - context
+- package: google.golang.org/api
+  subpackages:
+  - iterator

--- a/main.go
+++ b/main.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/urfave/cli"
+
+	"golang.org/x/net/context"
+	"google.golang.org/api/iterator"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "pubsub-devsub"
+	app.Usage = "github.com/akm/pubsub-devsub"
+	app.Version = Version
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:   "project",
+			Usage:  "GCS Project ID",
+			EnvVar: "GCP_PROJECT,PROJECT",
+		},
+		cli.StringFlag{
+			Name:   "datasource",
+			Usage:  "Data source name to your database",
+			EnvVar: "DATASOURCE",
+		},
+		cli.StringFlag{
+			Name:   "agent-root-url, A",
+			Usage:  "URL to your blocks-concurrent-batch-agent root",
+			EnvVar: "AGENT_URL",
+		},
+		cli.StringFlag{
+			Name:   "agent-token, T",
+			Usage:  "Authorization token for blocks-concurrent-batch-agent",
+			EnvVar: "AGENT_TOKEN",
+		},
+		cli.UintFlag{
+			Name:  "interval",
+			Value: 10,
+			Usage: "Interval to pull",
+		},
+	}
+
+	app.Action = executeCommand
+
+	app.Run(os.Args)
+}
+
+func executeCommand(c *cli.Context) error {
+
+	proj := c.String("project")
+	if proj == "" {
+		cli.ShowAppHelp(c)
+		os.Exit(1)
+	}
+	interval := c.Uint("interval")
+
+	httpClient := new(http.Client)
+
+	ctx := context.Background()
+	pubsubClient, err := pubsub.NewClient(ctx, proj)
+	if err != nil {
+		fmt.Println("Failed to get new pubsubClient for ", proj, " cause of ", err)
+		os.Exit(1)
+	}
+
+	db, err := sql.Open("mysql", c.String("datasource"))
+	if err != nil {
+		fmt.Println("Failed to get database connection for ", c.String("datasource"), " cause of ", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	for {
+		p := &Process{
+			httpClient:   httpClient,
+			httpUrl:      c.String("agent-url"),
+			httpToken:    c.String("agent-token"),
+			pubsubClient: pubsubClient,
+			db:           db,
+			command_args: c.Args(),
+		}
+		p.execute(ctx)
+
+		time.Sleep(time.Duration(interval) * time.Second)
+	}
+
+	return nil
+}
+
+type Process struct {
+	httpClient   *http.Client
+	httpUrl      string
+	httpToken    string
+	pubsubClient *pubsub.Client
+	db           *sql.DB
+	command_args []string
+}
+
+type Subscription struct {
+	Pipeline string `json:"pipeline"`
+	Name     string `json:"subscription"`
+}
+
+func (p *Process) execute(ctx context.Context) error {
+	subscriptions, err := p.getSubscriptions(ctx)
+	if err != nil {
+		return err
+	}
+	for _, sub := range subscriptions {
+		p.pullAndSave(ctx, sub)
+	}
+	return nil
+}
+
+func (p *Process) getSubscriptions(ctx context.Context) ([]*Subscription, error) {
+	req, err := http.NewRequest("GET", p.httpUrl+"/pipelines/subscriptions", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.httpToken)
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	byteArray, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var subscriptions []Subscription
+	err = json.Unmarshal(byteArray, &subscriptions)
+	if err != nil {
+		return nil, err
+	}
+	result := []*Subscription{}
+	for _, subscription := range subscriptions {
+		result = append(result, &subscription)
+	}
+	return result, nil
+}
+
+const (
+	SQL_UPDATE_JOBS = "UPDATE pipeline_jobs SET status = ? WHERE message_id = ? AND status < ?"
+	SQL_INSERT_LOGS = "INSERT INTO pipeline_job_logs (pipeline, message_id, status, publish_time) VALUES (?, ?, ?, ?)"
+)
+
+func (p *Process) pullAndSave(ctx context.Context, subscription *Subscription) error {
+	sub := p.pubsubClient.Subscription(subscription.Name)
+	it, err := sub.Pull(ctx)
+	if err != nil {
+		fmt.Println("Failed to pull from ", subscription, " cause of ", err)
+		return err
+	}
+	// Ensure that the iterator is closed down cleanly.
+	defer it.Stop()
+
+	for {
+		m, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			fmt.Println("Failed to get pulled message from ", subscription, " cause of ", err)
+			return err
+		}
+
+		// https://github.com/groovenauts/magellan-gcs-proxy/blob/master/lib/magellan/gcs/proxy/progress_notification.rb#L24
+		msg_id := m.Attributes["job_message_id"]
+		progress, err := strconv.Atoi(m.Attributes["progress"])
+		if err != nil {
+			fmt.Println("Failed to convert %v to int message_id: %v cause of %v", m.Attributes["progress"], msg_id, err)
+			return err
+		}
+
+		err = p.transaction(func(tx *sql.Tx) error {
+			_, err = tx.Exec(SQL_UPDATE_JOBS, progress, msg_id, progress)
+			if err != nil {
+				fmt.Println("Failed to update pipeline_jobs message_id: %v to status: %v cause of %v", msg_id, progress, err)
+				return err
+			}
+
+			_, err = tx.Exec(SQL_INSERT_LOGS, subscription.Pipeline, msg_id, progress, m.PublishTime)
+			if err != nil {
+				fmt.Println("Failed to insert pipeline_job_logs pipeline: %v, message_id: %v, status: %v cause of %v", subscription.Pipeline, msg_id, progress, err)
+				return err
+			}
+
+			// Execute command to notify
+			if len(p.command_args) > 0 {
+				name := p.command_args[0]
+				args := p.command_args[1:] // TODO how should the parameters be passed
+				cmd := exec.Command(name, args...)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				err = cmd.Run()
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			fmt.Println("Failed to begin a transaction message_id: %v to status: %v cause of %v", msg_id, progress, err)
+			return err
+		}
+
+		m.Done(true)
+	}
+	return nil
+}
+
+func (p *Process) transaction(impl func(tx *sql.Tx) error) error {
+	tx, err := p.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := recover(); err != nil {
+			tx.Rollback()
+		}
+	}()
+	err = impl(tx)
+	if err == nil {
+		tx.Commit()
+		return nil
+	} else {
+		tx.Rollback()
+		return err
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,13 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
-	"strconv"
 	"time"
-
-	"cloud.google.com/go/pubsub"
 
 	"github.com/urfave/cli"
 
@@ -93,68 +88,4 @@ func executeCommand(c *cli.Context) error {
 	}
 
 	return nil
-}
-
-type AgentApi interface {
-	getSubscriptions(ctx context.Context) ([]*Subscription, error)
-}
-
-type MessageSubscriber interface {
-	subscribe(ctx context.Context, subscription *Subscription, f func(msg *pubsub.Message) error ) error
-}
-
-type MessageStore interface {
-	save(ctx context.Context, pipeline, msg_id string, progress int, publishTime time.Time, f func() error ) error
-}
-
-
-type Process struct {
-	agentApi     AgentApi
-	subscriber   MessageSubscriber
-	messageStore MessageStore
-	command_args []string
-}
-
-type Subscription struct {
-	Pipeline string `json:"pipeline"`
-	Name     string `json:"subscription"`
-}
-
-func (p *Process) execute(ctx context.Context) error {
-	subscriptions, err := p.agentApi.getSubscriptions(ctx)
-	if err != nil {
-		return err
-	}
-	for _, sub := range subscriptions {
-		p.pullAndSave(ctx, sub)
-	}
-	return nil
-}
-
-func (p *Process) pullAndSave(ctx context.Context, subscription *Subscription) error {
-	err := p.subscriber.subscribe(ctx, subscription, func(m *pubsub.Message) error {
-		// https://github.com/groovenauts/magellan-gcs-proxy/blob/master/lib/magellan/gcs/proxy/progress_notification.rb#L24
-		msg_id := m.Attributes["job_message_id"]
-		progress, err := strconv.Atoi(m.Attributes["progress"])
-		if err != nil {
-			fmt.Println("Failed to convert %v to int message_id: %v cause of %v", m.Attributes["progress"], msg_id, err)
-			return err
-		}
-
-		err = p.messageStore.save(ctx, subscription.Pipeline, msg_id, progress, m.PublishTime, func() error{
-			// Execute command to notify
-			if len(p.command_args) > 0 {
-				name := p.command_args[0]
-				args := p.command_args[1:] // TODO how should the parameters be passed
-				cmd := exec.Command(name, args...)
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-				err = cmd.Run()
-				return err
-			}
-			return nil
-		})
-		return err
-	})
-	return err
 }

--- a/main.go
+++ b/main.go
@@ -131,11 +131,6 @@ func (p *Process) execute(ctx context.Context) error {
 	return nil
 }
 
-const (
-	SQL_UPDATE_JOBS = "UPDATE pipeline_jobs SET status = ? WHERE message_id = ? AND status < ?"
-	SQL_INSERT_LOGS = "INSERT INTO pipeline_job_logs (pipeline, message_id, status, publish_time) VALUES (?, ?, ?, ?)"
-)
-
 func (p *Process) pullAndSave(ctx context.Context, subscription *Subscription) error {
 	err := p.subscriber.subscribe(ctx, subscription, func(m *pubsub.Message) error {
 		// https://github.com/groovenauts/magellan-gcs-proxy/blob/master/lib/magellan/gcs/proxy/progress_notification.rb#L24

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func executeCommand(c *cli.Context) error {
 	for {
 		p := &Process{
 			agentApi:     &DefaultAgentClient{
-				httpUrl:   c.String("agent-url"),
+				httpUrl:   c.String("agent-root-url"),
 				httpToken: c.String("agent-token"),
 			},
 			subscriber:   pubsubClient,

--- a/migrations/down.sql
+++ b/migrations/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE `pipeline_job_logs`;
+DROP TABLE `pipeline_jobs`;

--- a/migrations/up.sql
+++ b/migrations/up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `pipeline_jobs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `pipeline` varchar(255) NOT NULL,
+  `message_id` varchar(255) DEFAULT NULL,
+  `status` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE `pipeline_job_logs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `pipeline` varchar(255) NOT NULL,
+  `status` int(11) NOT NULL,
+  `message_id` varchar(255) NOT NULL,
+  `publish_time` datetime NOT NULL,
+  PRIMARY KEY (`id`),
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/migrations/up.sql
+++ b/migrations/up.sql
@@ -9,8 +9,8 @@ CREATE TABLE `pipeline_jobs` (
 CREATE TABLE `pipeline_job_logs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pipeline` varchar(255) NOT NULL,
-  `status` int(11) NOT NULL,
   `message_id` varchar(255) NOT NULL,
+  `status` int(11) NOT NULL,
   `publish_time` datetime NOT NULL,
-  PRIMARY KEY (`id`),
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/process.go
+++ b/process.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+
+	"golang.org/x/net/context"
+)
+
+type AgentApi interface {
+	getSubscriptions(ctx context.Context) ([]*Subscription, error)
+}
+
+type MessageSubscriber interface {
+	subscribe(ctx context.Context, subscription *Subscription, f func(msg *pubsub.Message) error ) error
+}
+
+type MessageStore interface {
+	save(ctx context.Context, pipeline, msg_id string, progress int, publishTime time.Time, f func() error ) error
+}
+
+
+type Process struct {
+	agentApi     AgentApi
+	subscriber   MessageSubscriber
+	messageStore MessageStore
+	command_args []string
+}
+
+type Subscription struct {
+	Pipeline string `json:"pipeline"`
+	Name     string `json:"subscription"`
+}
+
+func (p *Process) execute(ctx context.Context) error {
+	subscriptions, err := p.agentApi.getSubscriptions(ctx)
+	if err != nil {
+		return err
+	}
+	for _, sub := range subscriptions {
+		p.pullAndSave(ctx, sub)
+	}
+	return nil
+}
+
+func (p *Process) pullAndSave(ctx context.Context, subscription *Subscription) error {
+	err := p.subscriber.subscribe(ctx, subscription, func(m *pubsub.Message) error {
+		// https://github.com/groovenauts/magellan-gcs-proxy/blob/master/lib/magellan/gcs/proxy/progress_notification.rb#L24
+		msg_id := m.Attributes["job_message_id"]
+		progress, err := strconv.Atoi(m.Attributes["progress"])
+		if err != nil {
+			fmt.Println("Failed to convert %v to int message_id: %v cause of %v", m.Attributes["progress"], msg_id, err)
+			return err
+		}
+
+		err = p.messageStore.save(ctx, subscription.Pipeline, msg_id, progress, m.PublishTime, func() error{
+			// Execute command to notify
+			if len(p.command_args) > 0 {
+				name := p.command_args[0]
+				args := p.command_args[1:] // TODO how should the parameters be passed
+				cmd := exec.Command(name, args...)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				err = cmd.Run()
+				return err
+			}
+			return nil
+		})
+		return err
+	})
+	return err
+}

--- a/process.go
+++ b/process.go
@@ -40,8 +40,10 @@ type Subscription struct {
 func (p *Process) execute(ctx context.Context) error {
 	subscriptions, err := p.agentApi.getSubscriptions(ctx)
 	if err != nil {
+		fmt.Println("Process.execute() err: %v", err)
 		return err
 	}
+	fmt.Println("Process.execute() subscriptions: %v", subscriptions)
 	for _, sub := range subscriptions {
 		p.pullAndSave(ctx, sub)
 	}
@@ -50,6 +52,8 @@ func (p *Process) execute(ctx context.Context) error {
 
 func (p *Process) pullAndSave(ctx context.Context, subscription *Subscription) error {
 	err := p.subscriber.subscribe(ctx, subscription, func(m *pubsub.Message) error {
+		fmt.Println("Process.pullAndSave message: %v", m)
+
 		// https://github.com/groovenauts/magellan-gcs-proxy/blob/master/lib/magellan/gcs/proxy/progress_notification.rb#L24
 		msg_id := m.Attributes["job_message_id"]
 		progress, err := strconv.Atoi(m.Attributes["progress"])

--- a/process.go
+++ b/process.go
@@ -43,7 +43,6 @@ func (p *Process) execute(ctx context.Context) error {
 		fmt.Println("Process.execute() err: %v", err)
 		return err
 	}
-	fmt.Println("Process.execute() subscriptions: %v", subscriptions)
 	for _, sub := range subscriptions {
 		p.pullAndSave(ctx, sub)
 	}
@@ -52,8 +51,6 @@ func (p *Process) execute(ctx context.Context) error {
 
 func (p *Process) pullAndSave(ctx context.Context, subscription *Subscription) error {
 	err := p.subscriber.subscribe(ctx, subscription, func(m *pubsub.Message) error {
-		fmt.Println("Process.pullAndSave message: %v", m)
-
 		// https://github.com/groovenauts/magellan-gcs-proxy/blob/master/lib/magellan/gcs/proxy/progress_notification.rb#L24
 		msg_id := m.Attributes["job_message_id"]
 		progress, err := strconv.Atoi(m.Attributes["progress"])

--- a/process_test.go
+++ b/process_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/net/context"
+)
+
+type DummyAgentApi struct {}
+func (dh *DummyAgentApi) getSubscriptions(ctx context.Context) ([]*Subscription, error) {
+	return []*Subscription{
+		&Subscription{Pipeline: "pipeline01", Name: "pipeline01-progress-subscription"},
+	}, nil
+}
+
+type DummySubscriber struct{}
+func (ds *DummySubscriber) subscribe(ctx context.Context, subscription *Subscription, f func(msg *pubsub.Message) error ) error {
+	msg := &pubsub.Message{
+		Attributes: map[string]string{
+			"job_message_id": "0123456789",
+			"progress": "14",
+		},
+		PublishTime: time.Now(),
+	}
+	return f(msg)
+}
+
+type DummyStore struct{}
+func (ds *DummyStore) save(ctx context.Context, pipeline, msg_id string, progress int, publishTime time.Time, f func() error ) error {
+	if "pipeline01" != pipeline {
+		return fmt.Errorf("pipeline should be pipeline01 but was %v", pipeline)
+	}
+	if "0123456789" != msg_id {
+		return fmt.Errorf("msg_id should be 0123456789 but was %v", msg_id)
+	}
+	if 14 != progress {
+		return fmt.Errorf("progress should be 14 but was %v", progress)
+	}
+	return nil
+}
+
+func TestExecute(t *testing.T) {
+	pr := &Process{
+		agentApi: &DummyAgentApi{},
+		subscriber: &DummySubscriber{},
+		messageStore: &DummyStore{},
+		command_args: []string{},
+	}
+
+	ctx := context.Background()
+	err := pr.execute(ctx)
+	assert.NoError(t, err)
+}

--- a/progress_store.go
+++ b/progress_store.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"runtime"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	"golang.org/x/net/context"
+)
+
+type SqlStore struct {
+	db *sql.DB
+}
+
+func (ss *SqlStore) setup(ctx context.Context, driver, datasource string) (func() error, error) {
+	db, err := sql.Open("mysql", datasource)
+	if err != nil {
+		fmt.Println("Failed to get database connection for ", datasource, " cause of ", err)
+		return nil, err
+	}
+	return db.Close, nil
+}
+
+func (ss *SqlStore) save(ctx context.Context, pipeline, msg_id string, progress int, publishTime time.Time, f func() error ) error {
+	err := ss.transaction(func(tx *sql.Tx) error {
+		_, err := tx.Exec(SQL_UPDATE_JOBS, progress, msg_id, progress)
+		if err != nil {
+			fmt.Println("Failed to update pipeline_jobs message_id: %v to status: %v cause of %v", msg_id, progress, err)
+			return err
+		}
+
+		_, err = tx.Exec(SQL_INSERT_LOGS, pipeline, msg_id, progress, publishTime)
+		if err != nil {
+			fmt.Println("Failed to insert pipeline_job_logs pipeline: %v, message_id: %v, status: %v cause of %v", pipeline, msg_id, progress, err)
+			return err
+		}
+
+		if f != nil {
+			err = f()
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		fmt.Println("Failed to begin a transaction message_id: %v to status: %v cause of %v", msg_id, progress, err)
+	}
+	return err
+}
+
+// Use "err" for returned variable name in order to return the error on recover.
+func (ss *SqlStore) transaction(impl func(tx *sql.Tx) error) (err error) {
+	tx, err := ss.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			tx.Rollback()
+			if _, ok := r.(runtime.Error); ok {
+				panic(r)
+			}
+			err = r.(error)
+		}
+	}()
+	err = impl(tx)
+	if err == nil {
+		tx.Commit()
+	} else {
+		tx.Rollback()
+	}
+	return err
+}

--- a/progress_store.go
+++ b/progress_store.go
@@ -11,6 +11,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	SQL_UPDATE_JOBS = "UPDATE pipeline_jobs SET status = ? WHERE message_id = ? AND status < ?"
+	SQL_INSERT_LOGS = "INSERT INTO pipeline_job_logs (pipeline, message_id, status, publish_time) VALUES (?, ?, ?, ?)"
+)
+
 type SqlStore struct {
 	db *sql.DB
 }

--- a/pubsub_client.go
+++ b/pubsub_client.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+
+	"cloud.google.com/go/pubsub"
+
+	"golang.org/x/net/context"
+	"google.golang.org/api/iterator"
+)
+
+type PubsubClient struct{
+	impl *pubsub.Client
+}
+
+func (pc *PubsubClient) setup(ctx context.Context, proj string) error {
+	client, err := pubsub.NewClient(ctx, proj)
+	if err != nil {
+		fmt.Println("Failed to get new pubsubClient for ", proj, " cause of ", err)
+		return err
+	}
+	pc.impl = client
+	return nil
+}
+
+func (pc *PubsubClient) subscribe(ctx context.Context, subscription *Subscription, f func(msg *pubsub.Message) error ) error {
+
+	sub := pc.impl.Subscription(subscription.Name)
+	it, err := sub.Pull(ctx)
+	if err != nil {
+		fmt.Println("Failed to pull from ", subscription, " cause of ", err)
+		return err
+	}
+	// Ensure that the iterator is closed down cleanly.
+	defer it.Stop()
+
+	for {
+		m, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			fmt.Println("Failed to get pulled message from ", subscription, " cause of ", err)
+			return err
+		}
+
+		err = f(m)
+
+		m.Done(err == nil)
+	}
+	return nil
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package main
+
+const Version = "0.0.1"


### PR DESCRIPTION
This is the first PR of `blocks-concurrent-subscriber`.
It subscribes the progresses of jobs with `blocks concurrent batch board` of [magellan-blocks](https://www.magellanic-clouds.com/blocks/).
The progress messages are published as cloud pubsub message.

## With MySQL

When the progresses are notified, `blocks-concurrent-subscriber` updates the status of the job and inserts logs on mysql.
See https://github.com/groovenauts/blocks-concurrent-subscriber/pull/1/files#diff-f7ac11a1616b17e063ea783346ecd8a3 for the tables' DDL.

## With blocks-concurrent-batch-agent

`blocks-concurrent-subscriber` access to `blocks-concurrent-batch-agent` to get subscriptions to pull messages.
So `blocks-concurrent-subscriber` depends on the API `/pipelines/subscriptions` of `blocks-concurrent-batch-agent` which is defined by https://github.com/groovenauts/blocks-concurrent-batch-agent/pull/9 .
