### PR TITLE
Dispatch commands for notification messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ go:
   - 1.6.4
 services:
   - mysql
-before_install:
-  - make testsetup
 addons:
   apt:
     sources:
@@ -14,6 +12,7 @@ addons:
       - glide
 before_install:
   - test -d $GOPATH/bin || mkdir -p $GOPATH/bin
+  - make testsetup
 install:
   ## Install dependencies
   - glide install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 language: go
 go:
   - 1.6.4
+services:
+  - mysql
+before_install:
+  - make testsetup
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,12 @@ addons:
       - glide
 before_install:
   - test -d $GOPATH/bin || mkdir -p $GOPATH/bin
+  - make checksetup
   - make testsetup
 install:
   ## Install dependencies
   - glide install
+before_script:
+  - make check
 script:
   - go test

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,16 @@ testteardown:
 	mysql -u root blocks_subscriber_test < migrations/down.sql
 	mysql -u root -e "DROP DATABASE IF EXISTS blocks_subscriber_test;"
 
-check:
+check: checkfmt
 	go vet *.go
 	goimports -l *.go
+
+checkfmt:
+ifneq ($(shell gofmt -l *.go),)
+	exit 1
+else
+	@echo "gofmt -l *.go OK"
+endif
 
 build:
 	mkdir -p ${PKGDIR}

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ testsetup:
 	mysql -u root -e "CREATE DATABASE IF NOT EXISTS blocks_subscriber_test DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;"
 	mysql -u root blocks_subscriber_test < migrations/up.sql
 
+testfixtures:
+	mysql -u root blocks_subscriber_test < test/setup.sql
+
 testteardown:
 	mysql -u root blocks_subscriber_test < migrations/down.sql
 	mysql -u root -e "DROP DATABASE IF EXISTS blocks_subscriber_test;"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ setup:
 	go get github.com/mitchellh/gox
 	go get github.com/tcnksm/ghr
 
+checksetup:
+	go get golang.org/x/tools/cmd/goimports
+
 testsetup:
 	mysql -u root -e "CREATE DATABASE IF NOT EXISTS blocks_subscriber_test DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;"
 	mysql -u root blocks_subscriber_test < migrations/up.sql
@@ -20,6 +23,10 @@ testfixtures:
 testteardown:
 	mysql -u root blocks_subscriber_test < migrations/down.sql
 	mysql -u root -e "DROP DATABASE IF EXISTS blocks_subscriber_test;"
+
+check:
+	go vet *.go
+	goimports -l *.go
 
 build:
 	mkdir -p ${PKGDIR}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+PKGDIR=./pkg
+BASENAME=blocks-concurrent-subscriber
+VERSION=`grep VERSION version.go | cut -f2 -d\"`
+OS=linux
+ARCH=amd64
+
+all: build
+
+setup:
+	go get github.com/mitchellh/gox
+	go get github.com/tcnksm/ghr
+
+testsetup:
+	mysql -u root -e "CREATE DATABASE IF NOT EXISTS blocks_subscriber_test DEFAULT CHARACTER SET utf8 COLLATE utf8_general_ci;"
+	mysql -u root blocks_subscriber_test < migrations/up.sql
+
+testteardown:
+	mysql -u root blocks_subscriber_test < migrations/down.sql
+	mysql -u root -e "DROP DATABASE IF EXISTS blocks_subscriber_test;"
+
+build:
+	mkdir -p ${PKGDIR}
+	gox -output="${PKGDIR}/{{.Dir}}_${OS}_${ARCH}" -os="${OS}" -arch="${ARCH}"
+
+release: build
+	ghr -u groovenauts -r blocks-concurrent-subscriber --replace --draft ${VERSION} pkg
+
+prerelease: build
+	ghr -u groovenauts -r blocks-concurrent-subscriber --replace --draft --prerelease ${VERSION} pkg
+
+version:
+	echo ${VERSION}
+
+clean:
+	rm -rf ${PKGDIR}

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BASENAME=blocks-concurrent-subscriber
 VERSION=`grep VERSION version.go | cut -f2 -d\"`
 OS=linux
 ARCH=amd64
+UNFORMATTED=$(shell gofmt -l *.go)
 
 all: build
 
@@ -29,7 +30,8 @@ check: checkfmt
 	goimports -l *.go
 
 checkfmt:
-ifneq ($(shell gofmt -l *.go),)
+ifneq ($(UNFORMATTED),)
+	@echo $(UNFORMATTED)
 	exit 1
 else
 	@echo "gofmt -l *.go OK"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 731c43addfcd2c75d5cd50850a68895bbe4ed84684d7e24821915f38a9e3037f
-updated: 2017-02-20T20:23:04.67773+09:00
+hash: a32c4766c87f92ba3c0842531bdd1bd8b45c4e57357f40be864426900e569ff1
+updated: 2017-03-15T19:57:53.262187693+09:00
 imports:
 - name: cloud.google.com/go
   version: 81b7822b1e798e8f17bf64b59512a5be4097e966
@@ -14,6 +14,8 @@ imports:
   - proto
 - name: github.com/googleapis/gax-go
   version: da06d194a00e19ce00d9011a13931c3f6f6887c7
+- name: github.com/groovenauts/blocks-variable
+  version: 833d2f1e70b82c8a0a1149827906ab32aed40276
 - name: github.com/urfave/cli
   version: 347a9884a87374d000eec7e6445a34487c1f4a2b
 - name: golang.org/x/net

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,6 @@
 package: github.com/groovenauts/blocks-concurrent-subscriber
 import:
+- package: github.com/groovenauts/blocks-variable
 - package: github.com/go-sql-driver/mysql
 - package: github.com/urfave/cli
 - package: golang.org/x/net

--- a/main.go
+++ b/main.go
@@ -66,6 +66,4 @@ func executeCommand(c *cli.Context) error {
 
 		time.Sleep(time.Duration(config.Interval) * time.Second)
 	}
-
-	return nil
 }

--- a/main.go
+++ b/main.go
@@ -17,10 +17,10 @@ func main() {
 	app.Version = Version
 
 	app.Flags = []cli.Flag{
-    cli.StringFlag{
-      Name:  "config, c",
-      Usage: "Load configuration from `FILE`",
-    },
+		cli.StringFlag{
+			Name:  "config, c",
+			Usage: "Load configuration from `FILE`",
+		},
 	}
 
 	app.Action = executeCommand
@@ -60,7 +60,7 @@ func executeCommand(c *cli.Context) error {
 			},
 			subscriber:   pubsubSubscriber,
 			messageStore: store,
-			patterns: config.Patterns,
+			patterns:     config.Patterns,
 		}
 		p.execute(ctx)
 

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func executeCommand(c *cli.Context) error {
 			},
 			subscriber:   pubsubSubscriber,
 			messageStore: store,
-			command_args: c.Args(),
+			patterns: config.Patterns,
 		}
 		p.execute(ctx)
 

--- a/message.go
+++ b/message.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+type Message struct {
+	msg_id string
+	progress int
+	publishTime time.Time
+	data string
+}
+
+func (m *Message) load(attrs map[string]string) error {
+	m.msg_id = attrs["job_message_id"]
+	progress, err := strconv.Atoi(attrs["progress"])
+	if err != nil {
+		fmt.Printf("Failed to convert %v to int message_id: %v cause of %v", attrs["progress"], m.msg_id, err)
+		return err
+	}
+	m.progress = progress
+	return nil
+}
+
+func (m *Message) parse(publishTime string) error {
+	// https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
+	// A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
+	t, err := time.Parse(time.RFC3339, publishTime)
+	if err != nil {
+		fmt.Printf("Failed to parse publishTime(%v) message_id: %v cause of %v", m.publishTime, m.msg_id, err)
+		return err
+	}
+	m.publishTime = t
+	return nil
+}

--- a/message.go
+++ b/message.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Message struct {
-	msg_id string
-	progress int
+	msg_id      string
+	progress    int
 	publishTime time.Time
-	completed string
-	level string
-	data string
+	completed   string
+	level       string
+	data        string
 }
 
 func (m *Message) load(attrs map[string]string) error {
@@ -48,11 +48,11 @@ func (m *Message) completedInt() int {
 
 func (m *Message) buildMap() map[string]interface{} {
 	return map[string]interface{}{
-		"job_message_id":     m.msg_id,
-		"progress":						m.progress,
-		"publishTime":				m.publishTime,
-		"completed":					m.completed,
-		"level":							m.level,
-		"data":								m.data,
+		"job_message_id": m.msg_id,
+		"progress":       m.progress,
+		"publishTime":    m.publishTime,
+		"completed":      m.completed,
+		"level":          m.level,
+		"data":           m.data,
 	}
 }

--- a/message.go
+++ b/message.go
@@ -10,6 +10,8 @@ type Message struct {
 	msg_id string
 	progress int
 	publishTime time.Time
+	completed string
+	level string
 	data string
 }
 
@@ -34,4 +36,15 @@ func (m *Message) parse(publishTime string) error {
 	}
 	m.publishTime = t
 	return nil
+}
+
+func (m *Message) buildMap() map[string]interface{} {
+	return map[string]interface{}{
+		"job_message_id":     m.msg_id,
+		"progress":						m.progress,
+		"publishTime":				m.publishTime,
+		"completed":					m.completed,
+		"level":							m.level,
+		"data":								m.data,
+	}
 }

--- a/message.go
+++ b/message.go
@@ -38,6 +38,14 @@ func (m *Message) parse(publishTime string) error {
 	return nil
 }
 
+func (m *Message) completedInt() int {
+	if m.completed == "true" {
+		return 1
+	} else {
+		return 0
+	}
+}
+
 func (m *Message) buildMap() map[string]interface{} {
 	return map[string]interface{}{
 		"job_message_id":     m.msg_id,

--- a/migrations/down.sql
+++ b/migrations/down.sql
@@ -1,2 +1,2 @@
-DROP TABLE `pipeline_job_logs`;
-DROP TABLE `pipeline_jobs`;
+DROP TABLE IF EXISTS `pipeline_job_logs`;
+DROP TABLE IF EXISTS `pipeline_jobs`;

--- a/migrations/up.sql
+++ b/migrations/up.sql
@@ -1,16 +1,19 @@
 CREATE TABLE `pipeline_jobs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pipeline` varchar(255) NOT NULL,
-  `message_id` varchar(255) DEFAULT NULL,
-  `status` int(11) NOT NULL,
-  PRIMARY KEY (`id`),
+  `job_message_id` varchar(255) DEFAULT NULL,
+  `progress` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `pipeline_job_logs` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `pipeline` varchar(255) NOT NULL,
-  `message_id` varchar(255) NOT NULL,
-  `status` int(11) NOT NULL,
+  `job_message_id` varchar(255) NOT NULL,
   `publish_time` datetime NOT NULL,
+  `progress` int(11) NOT NULL,
+  `completed` tinyint NOT NULL,
+  `log_level` varchar(10) NOT NULL,
+  `log_message` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/pattern.go
+++ b/pattern.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+)
+
+type Pattern struct {
+	Completed string `json:"completed"`
+	Level string     `json:"level"`
+	Command []string `json:"command"`
+}
+
+func (p *Pattern) execute(msg *Message) error {
+	if !p.match(msg) {
+		return nil
+	}
+	cmd, err := p.build(msg)
+	if err != nil {
+		return err
+	}
+	return cmd.Run()
+}
+
+func (p *Pattern) match(msg *Message) bool {
+	return false
+}
+
+func (p *Pattern) build(msg *Message) (*exec.Cmd, error) {
+
+	name := p.Command[0]
+	args := p.Command[1:] // TODO how should the parameters be passed
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd, nil
+}
+
+type Patterns []*Pattern
+
+func (pa Patterns) execute(msg *Message) error {
+	for _, ptn := range pa {
+		err := ptn.execute(msg)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pattern.go
+++ b/pattern.go
@@ -15,9 +15,9 @@ var (
 
 type Pattern struct {
 	Completed string `json:"completed"`
-	Level string     `json:"level"`
-	Data string
-	Command []string `json:"command"`
+	Level     string `json:"level"`
+	Data      string
+	Command   []string `json:"command"`
 }
 
 func (p *Pattern) execute(msg *Message) error {

--- a/pattern.go
+++ b/pattern.go
@@ -83,9 +83,11 @@ func (pa Patterns) oneFor(msg *Message) *Pattern {
 
 func (pa Patterns) execute(msg *Message) error {
 	for _, ptn := range pa {
-		err := ptn.execute(msg)
-		if err != nil {
-			return err
+		if ptn.match(msg) {
+			err := ptn.execute(msg)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	// "fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPatternsExecute(t *testing.T) {
+	patterns := Patterns{
+		&Pattern{
+			Completed: "true",
+			Command: []string{"echo", "COMPLETED %{data}"},
+		},
+		&Pattern{
+			Level: "fatal",
+			Command: []string{"echo", "FATAL %{data}"},
+		},
+		&Pattern{
+			Level: "error",
+			Command: []string{"grep", "--invalid", "option"},
+		},
+	}
+
+	testPatterns := []struct {
+		msg *Message
+		err string
+		stdout string
+		stderr string
+	}{
+		{
+			msg: &Message{
+				msg_id: "test-msg1",
+				progress: 5,
+				publishTime: time.Now(),
+				completed: "true",
+				level: "info",
+				data: "SUCCESS",
+			},
+			stdout: "COMPLETED SUCCESS",
+			stderr: "",
+		},
+		{
+			msg: &Message{
+				msg_id: "test-msg2",
+				progress: 2,
+				publishTime: time.Now(),
+				completed: "false",
+				level: "fatal",
+				data: "panic!",
+			},
+			stdout: "FATAL panic!",
+			stderr: "",
+		},
+		{
+			msg: &Message{
+				msg_id: "test-msg3",
+				progress: 3,
+				publishTime: time.Now(),
+				completed: "false",
+				level: "error",
+				data: "",
+			},
+			err: "exit status 2",
+			stdout: "",
+			stderr: "unrecognized option",
+		},
+	}
+
+	for _, testPattern := range testPatterns {
+		bufStdout := &bytes.Buffer{}
+		bufStderr := &bytes.Buffer{}
+		CommandStdout = bufStdout
+		CommandStderr = bufStderr
+		err := patterns.executeOne(testPattern.msg)
+		if testPattern.err != "" {
+			assert.Regexp(t, testPattern.err, err.Error())
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Regexp(t, testPattern.stdout, bufStdout.String())
+		assert.Regexp(t, testPattern.stderr, bufStderr.String())
+	}
+}

--- a/pattern_test.go
+++ b/pattern_test.go
@@ -13,69 +13,69 @@ func TestPatternsExecute(t *testing.T) {
 	patterns := Patterns{
 		&Pattern{
 			Completed: "true",
-			Command: []string{"echo", "COMPLETED %{data}"},
+			Command:   []string{"echo", "COMPLETED %{data}"},
 		},
 		&Pattern{
-			Level: "fatal",
+			Level:   "fatal",
 			Command: []string{"echo", "FATAL %{data}"},
 		},
 		&Pattern{
-			Level: "error",
+			Level:   "error",
 			Command: []string{"grep", "--invalid", "option"},
 		},
 	}
 
 	testPatterns := []struct {
-		msg *Message
-		err string
+		msg    *Message
+		err    string
 		stdout string
 		stderr string
 	}{
 		{
 			msg: &Message{
-				msg_id: "test-msg1",
-				progress: 5,
+				msg_id:      "test-msg1",
+				progress:    5,
 				publishTime: time.Now(),
-				completed: "true",
-				level: "info",
-				data: "SUCCESS",
+				completed:   "true",
+				level:       "info",
+				data:        "SUCCESS",
 			},
 			stdout: "COMPLETED SUCCESS",
 			stderr: "",
 		},
 		{
 			msg: &Message{
-				msg_id: "test-msg2",
-				progress: 2,
+				msg_id:      "test-msg2",
+				progress:    2,
 				publishTime: time.Now(),
-				completed: "false",
-				level: "fatal",
-				data: "panic!",
+				completed:   "false",
+				level:       "fatal",
+				data:        "panic!",
 			},
 			stdout: "FATAL panic!",
 			stderr: "",
 		},
 		{
 			msg: &Message{
-				msg_id: "test-msg3",
-				progress: 3,
+				msg_id:      "test-msg3",
+				progress:    3,
 				publishTime: time.Now(),
-				completed: "false",
-				level: "error",
-				data: "",
+				completed:   "false",
+				level:       "error",
+				data:        "",
 			},
-			err: "exit status 2",
+			err:    "exit status 2",
 			stdout: "",
 			stderr: "unrecognized option",
 		},
 		{
 			msg: &Message{
-				msg_id: "test-msg4",
-				progress: 1,
+				msg_id:      "test-msg4",
+				progress:    1,
 				publishTime: time.Now(),
-				completed: "false",
-				level: "debug",
-				data: "Mismatch",
+				completed:   "false",
+				level:       "debug",
+				data:        "Mismatch",
 			},
 			stdout: "",
 			stderr: "",

--- a/process.go
+++ b/process.go
@@ -35,7 +35,7 @@ type Subscription struct {
 func (p *Process) execute(ctx context.Context) error {
 	subscriptions, err := p.agentApi.getSubscriptions(ctx)
 	if err != nil {
-		fmt.Println("Process.execute() err: %v", err)
+		fmt.Println("Process.execute() err: ", err)
 		return err
 	}
 	for _, sub := range subscriptions {

--- a/process_config.go
+++ b/process_config.go
@@ -10,11 +10,11 @@ import (
 )
 
 type ProcessConfig struct {
-	Datasource string        `json:"datasource"`
-	AgentRootUrl string      `json:"agent-root-url"`
-	AgentRootToken string    `json:"agent-root-token"`
-	Interval int             `json:"interval"`
-	Patterns []*Pattern       `json:"patterns"`
+	Datasource     string     `json:"datasource"`
+	AgentRootUrl   string     `json:"agent-root-url"`
+	AgentRootToken string     `json:"agent-root-token"`
+	Interval       int        `json:"interval"`
+	Patterns       []*Pattern `json:"patterns"`
 }
 
 func LoadProcessConfig(path string) (*ProcessConfig, error) {

--- a/process_config.go
+++ b/process_config.go
@@ -9,21 +9,13 @@ import (
 	"text/template"
 )
 
-type (
-	PatternConfig struct {
-		Completed string   `json:"completed"`
-		Level string     `json:"level"`
-		Command []string `json:"command"`
-	}
-
-	ProcessConfig struct {
-		Datasource string        `json:"datasource"`
-		AgentRootUrl string      `json:"agent-root-url"`
-		AgentRootToken string    `json:"agent-root-token"`
-		Interval int             `json:"interval"`
-		Patterns []PatternConfig `json:"patterns"`
-	}
-)
+type ProcessConfig struct {
+	Datasource string        `json:"datasource"`
+	AgentRootUrl string      `json:"agent-root-url"`
+	AgentRootToken string    `json:"agent-root-token"`
+	Interval int             `json:"interval"`
+	Patterns []*Pattern       `json:"patterns"`
+}
 
 func LoadProcessConfig(path string) (*ProcessConfig, error) {
 	raw, err := ioutil.ReadFile(path)

--- a/process_config.go
+++ b/process_config.go
@@ -11,7 +11,7 @@ import (
 
 type (
 	PatternConfig struct {
-		Completed bool   `json:"completed"`
+		Completed string   `json:"completed"`
 		Level string     `json:"level"`
 		Command []string `json:"command"`
 	}

--- a/process_config.go
+++ b/process_config.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"strings"
+	"text/template"
+)
+
+type (
+	PatternConfig struct {
+		Completed bool   `json:"completed"`
+		Level string     `json:"level"`
+		Command []string `json:"command"`
+	}
+
+	ProcessConfig struct {
+		Datasource string        `json:"datasource"`
+		AgentRootUrl string      `json:"agent-root-url"`
+		AgentRootToken string    `json:"agent-root-token"`
+		Interval int             `json:"interval"`
+		Patterns []PatternConfig `json:"patterns"`
+	}
+)
+
+func LoadProcessConfig(path string) (*ProcessConfig, error) {
+	raw, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	funcMap := template.FuncMap{"env": os.Getenv}
+	t, err := template.New("config").Funcs(funcMap).Parse(string(raw))
+	if err != nil {
+		return nil, err
+	}
+
+	env := map[string]string{}
+	for _, s := range os.Environ() {
+		parts := strings.SplitN(s, "=", 2)
+		env[parts[0]] = parts[1]
+	}
+
+	buf := new(bytes.Buffer)
+	t.Execute(buf, env)
+
+	var res ProcessConfig
+	err = json.Unmarshal(buf.Bytes(), &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}

--- a/process_config_test.go
+++ b/process_config_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadProcessConfig(t *testing.T) {
+	config, err := LoadProcessConfig("./test/config1.json")
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, config.Datasource)
+	assert.NotEmpty(t, config.AgentRootUrl)
+	assert.NotEmpty(t, config.AgentRootToken)
+	assert.Equal(t, 10, config.Interval)
+	if assert.NotNil(t, config.Patterns) {
+		assert.Equal(t, 2, len(config.Patterns))
+	}
+}

--- a/process_test.go
+++ b/process_test.go
@@ -37,15 +37,15 @@ func (ds *DummySubscriber) subscribe(ctx context.Context, subscription *Subscrip
 
 type DummyStore struct{}
 
-func (ds *DummyStore) save(ctx context.Context, pipeline, msg_id string, progress int, publishTime time.Time, f func() error) error {
+func (ds *DummyStore) save(ctx context.Context, pipeline string, msg *Message, f func() error) error {
 	if "pipeline01" != pipeline {
 		return fmt.Errorf("pipeline should be pipeline01 but was %v", pipeline)
 	}
-	if "0123456789" != msg_id {
-		return fmt.Errorf("msg_id should be 0123456789 but was %v", msg_id)
+	if "0123456789" != msg.msg_id {
+		return fmt.Errorf("msg_id should be 0123456789 but was %v", msg.msg_id)
 	}
-	if 14 != progress {
-		return fmt.Errorf("progress should be 14 but was %v", progress)
+	if 14 != msg.progress {
+		return fmt.Errorf("progress should be 14 but was %v", msg.progress)
 	}
 	return nil
 }

--- a/process_test.go
+++ b/process_test.go
@@ -55,7 +55,7 @@ func TestExecute(t *testing.T) {
 		agentApi:     &DummyAgentApi{},
 		subscriber:   &DummySubscriber{},
 		messageStore: &DummyStore{},
-		command_args: []string{},
+		patterns:     Patterns{},
 	}
 
 	ctx := context.Background()

--- a/progress_store.go
+++ b/progress_store.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"runtime"
-	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 
@@ -31,17 +30,17 @@ func (ss *SqlStore) setup(ctx context.Context, driver, datasource string) (func(
 	return db.Close, nil
 }
 
-func (ss *SqlStore) save(ctx context.Context, pipeline, msg_id string, progress int, publishTime time.Time, f func() error) error {
+func (ss *SqlStore) save(ctx context.Context, pipeline string, msg *Message, f func() error) error {
 	err := ss.transaction(func(tx *sql.Tx) error {
-		_, err := tx.Exec(SQL_UPDATE_JOBS, progress, msg_id, progress)
+		_, err := tx.Exec(SQL_UPDATE_JOBS, msg.progress, msg.msg_id, msg.progress)
 		if err != nil {
-			fmt.Println("Failed to update pipeline_jobs message_id: %v to status: %v cause of %v", msg_id, progress, err)
+			fmt.Println("Failed to update pipeline_jobs message_id: %v to status: %v cause of %v", msg.msg_id, msg.progress, err)
 			return err
 		}
 
-		_, err = tx.Exec(SQL_INSERT_LOGS, pipeline, msg_id, progress, publishTime)
+		_, err = tx.Exec(SQL_INSERT_LOGS, pipeline, msg.msg_id, msg.progress, msg.publishTime)
 		if err != nil {
-			fmt.Println("Failed to insert pipeline_job_logs pipeline: %v, message_id: %v, status: %v cause of %v", pipeline, msg_id, progress, err)
+			fmt.Println("Failed to insert pipeline_job_logs pipeline: %v, message_id: %v, status: %v cause of %v", pipeline, msg.msg_id, msg.progress, err)
 			return err
 		}
 
@@ -53,7 +52,7 @@ func (ss *SqlStore) save(ctx context.Context, pipeline, msg_id string, progress 
 		return nil
 	})
 	if err != nil {
-		fmt.Println("Failed to begin a transaction message_id: %v to status: %v cause of %v", msg_id, progress, err)
+		fmt.Println("Failed to begin a transaction message_id: %v to status: %v cause of %v", msg.msg_id, msg.progress, err)
 	}
 	return err
 }

--- a/progress_store.go
+++ b/progress_store.go
@@ -34,13 +34,13 @@ func (ss *SqlStore) save(ctx context.Context, pipeline string, msg *Message, f f
 	err := ss.transaction(func(tx *sql.Tx) error {
 		_, err := tx.Exec(SQL_UPDATE_JOBS, msg.progress, msg.msg_id, msg.progress)
 		if err != nil {
-			fmt.Println("Failed to update pipeline_jobs job_message_id: %v to progress: %v cause of %v", msg.msg_id, msg.progress, err)
+			fmt.Printf("Failed to update pipeline_jobs job_message_id: %v to progress: %v cause of %v", msg.msg_id, msg.progress, err)
 			return err
 		}
 
 		_, err = tx.Exec(SQL_INSERT_LOGS, pipeline, msg.msg_id, msg.publishTime, msg.progress, msg.completedInt(), msg.level, msg.data)
 		if err != nil {
-			fmt.Println("Failed to insert pipeline_job_logs pipeline: %v, job_message_id: %v, progress: %v cause of %v", pipeline, msg.msg_id, msg.progress, err)
+			fmt.Printf("Failed to insert pipeline_job_logs pipeline: %v, job_message_id: %v, progress: %v cause of %v", pipeline, msg.msg_id, msg.progress, err)
 			return err
 		}
 
@@ -52,7 +52,7 @@ func (ss *SqlStore) save(ctx context.Context, pipeline string, msg *Message, f f
 		return nil
 	})
 	if err != nil {
-		fmt.Println("Failed to begin a transaction job_message_id: %v to progress: %v cause of %v", msg.msg_id, msg.progress, err)
+		fmt.Printf("Failed to begin a transaction job_message_id: %v to progress: %v cause of %v", msg.msg_id, msg.progress, err)
 	}
 	return err
 }

--- a/progress_store_test.go
+++ b/progress_store_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"database/sql"
+	"log"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	TEST_DATASOURCE = "root:@/blocks_subscriber_test"
+)
+
+func assertCount(t *testing.T, db *sql.DB, expected int, sql string, args ...interface{}) bool {
+	var cnt int
+	err := db.QueryRow(sql, args...).Scan(&cnt)
+	assert.NoError(t, err)
+	return assert.Equal(t, expected, cnt)
+}
+
+type PipelineJob struct {
+	id int
+	pipeline string
+	job_message_id string
+	progress int
+}
+
+const PIPELINE_JOBS_QUERY_BASE = "SELECT id, pipeline, job_message_id, progress FROM pipeline_jobs "
+
+func queryPipelineJob(db *sql.DB, where string, args ...interface{}) (*PipelineJob, error) {
+	r := PipelineJob{}
+	sql := PIPELINE_JOBS_QUERY_BASE + where
+	err := db.QueryRow(sql, args...).Scan(&r.id, &r.pipeline, &r.job_message_id, &r.progress)
+	return &r, err
+}
+
+func TestProgressStoreSave(t *testing.T) {
+	cmd := exec.Command("make", "testfixtures")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		log.Fatalf("Failed to load fixtures`\n")
+		return
+	}
+
+	ctx := context.Background()
+
+	store := &SqlStore{}
+	cb, err := store.setup(ctx, "mysql", TEST_DATASOURCE)
+	if err != nil {
+		log.Fatalf("Failed to connect DB: %q. Please run `make testsetup`\n", TEST_DATASOURCE)
+		return
+	}
+	defer cb()
+
+	db := store.db
+	
+	extraCalled := false
+	extra := func() error {
+		extraCalled = true
+		return nil
+	}
+	msg := &Message{
+		msg_id: "jm01",
+		progress: 2,
+		publishTime: time.Now(),
+		completed: "false",
+		level: "info",
+		data: "",
+	}
+
+	pl, err := queryPipelineJob(db, "WHERE pipeline='pipeline01' AND job_message_id=?", msg.msg_id)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, pl.progress)
+
+	store.save(ctx, "pipeline01", msg, extra)
+
+	pl, err = queryPipelineJob(db, "WHERE pipeline='pipeline01' AND job_message_id=?", msg.msg_id)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, pl.progress)
+
+	msg = &Message{
+		msg_id: "jm04",
+		progress: 2,
+		publishTime: time.Now(),
+		completed: "false",
+		level: "info",
+		data: "",
+	}
+
+	pl, err = queryPipelineJob(db, "WHERE pipeline='pipeline01' AND job_message_id=?", msg.msg_id)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, pl.progress)
+	
+	store.save(ctx, "pipeline01", msg, extra)
+
+	pl, err = queryPipelineJob(db, "WHERE pipeline='pipeline01' AND job_message_id=?", msg.msg_id)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, pl.progress)
+}

--- a/progress_store_test.go
+++ b/progress_store_test.go
@@ -25,10 +25,10 @@ func assertCount(t *testing.T, db *sql.DB, expected int, sql string, args ...int
 }
 
 type PipelineJob struct {
-	id int
-	pipeline string
+	id             int
+	pipeline       string
 	job_message_id string
-	progress int
+	progress       int
 }
 
 const PIPELINE_JOBS_QUERY_BASE = "SELECT id, pipeline, job_message_id, progress FROM pipeline_jobs "
@@ -61,19 +61,19 @@ func TestProgressStoreSave(t *testing.T) {
 	defer cb()
 
 	db := store.db
-	
+
 	extraCalled := false
 	extra := func() error {
 		extraCalled = true
 		return nil
 	}
 	msg := &Message{
-		msg_id: "jm01",
-		progress: 2,
+		msg_id:      "jm01",
+		progress:    2,
 		publishTime: time.Now(),
-		completed: "false",
-		level: "info",
-		data: "",
+		completed:   "false",
+		level:       "info",
+		data:        "",
 	}
 
 	pl, err := queryPipelineJob(db, "WHERE pipeline='pipeline01' AND job_message_id=?", msg.msg_id)
@@ -87,18 +87,18 @@ func TestProgressStoreSave(t *testing.T) {
 	assert.Equal(t, 2, pl.progress)
 
 	msg = &Message{
-		msg_id: "jm04",
-		progress: 2,
+		msg_id:      "jm04",
+		progress:    2,
 		publishTime: time.Now(),
-		completed: "false",
-		level: "info",
-		data: "",
+		completed:   "false",
+		level:       "info",
+		data:        "",
 	}
 
 	pl, err = queryPipelineJob(db, "WHERE pipeline='pipeline01' AND job_message_id=?", msg.msg_id)
 	assert.NoError(t, err)
 	assert.Equal(t, 4, pl.progress)
-	
+
 	store.save(ctx, "pipeline01", msg, extra)
 
 	pl, err = queryPipelineJob(db, "WHERE pipeline='pipeline01' AND job_message_id=?", msg.msg_id)

--- a/test/config1.json
+++ b/test/config1.json
@@ -5,12 +5,12 @@
   "interval": 10,
   "patterns": [
     {
-      "completed": true,
+      "completed": "true",
       "command": ["bin/rails", "r", "Model.complete('%{msg.job_message_id}')"]
     },
     {
       "level": "fatal",
-      "completed": false,
+      "completed": "false",
       "command": ["bin/rails", "r", "Model.fatalError(%{msg.job_message_id}, '%{msg.data}')"]
     }
   ]

--- a/test/config1.json
+++ b/test/config1.json
@@ -1,0 +1,17 @@
+{
+  "datasource": "root:@/database1",
+  "agent-root-url": "https://blocks-concurrent-batch-agent-somewhere.com",
+  "agent-root-token": "password1",
+  "interval": 10,
+  "patterns": [
+    {
+      "completed": true,
+      "command": ["bin/rails", "r", "Model.complete('%{msg.job_message_id}')"]
+    },
+    {
+      "level": "fatal",
+      "completed": false,
+      "command": ["bin/rails", "r", "Model.fatalError(%{msg.job_message_id}, '%{msg.data}')"]
+    }
+  ]
+}

--- a/test/setup.sql
+++ b/test/setup.sql
@@ -1,0 +1,16 @@
+DELETE FROM pipeline_jobs;
+INSERT INTO pipeline_jobs
+  (pipeline, job_message_id, progress)
+  VALUES
+  ('pipeline01', 'jm01', 1),
+  ('pipeline01', 'jm02', 2),
+  ('pipeline01', 'jm03', 3),
+  ('pipeline01', 'jm04', 4),
+  ('pipeline01', 'jm05', 5),
+  ('pipeline02', 'jm01', 1),
+  ('pipeline02', 'jm02', 2),
+  ('pipeline02', 'jm03', 3),
+  ('pipeline02', 'jm04', 4),
+  ('pipeline02', 'jm05', 5);
+
+DELETE FROM pipeline_job_logs;


### PR DESCRIPTION
In order to call different commands by notification messages, `blocks-concurrent-subscriber` select a command from commands in configuration file.

## Behavior changes

- The configurations must be in configuration file [example](https://github.com/groovenauts/blocks-concurrent-subscriber/blob/56d349568c62ffcf7bb1159c599d423d31d101b4/test/config1.json)
- The command argument is only `--config`
- Table schema changed [diff](https://github.com/groovenauts/blocks-concurrent-subscriber/commit/a80c13bbaabb7e0291fc57ab4e25c5a35f82b460#diff-f7ac11a1616b17e063ea783346ecd8a3)
- Expects attributes named`completed` and `level` in notification messages

## Other changes

- Use [blocks-variable](https://github.com/groovenauts/blocks-variable) to build command 
- Add a test with mysql database
- Add Makefile for build and test
