### PR TITLE
Don't quit on ack error after pipeline is closed

### DIFF
--- a/agent_client.go
+++ b/agent_client.go
@@ -25,13 +25,12 @@ func (e *InvalidHttpResponse) Error() string {
 }
 
 type InvalidPipeline struct {
-	Msg        string
+	Msg string
 }
 
 func (e *InvalidPipeline) Error() string {
 	return e.Msg
 }
-
 
 type DefaultAgentClient struct {
 	httpRequester HttpRequester
@@ -73,7 +72,7 @@ func (ac *DefaultAgentClient) getSubscriptions(ctx context.Context) ([]*Subscrip
 func (ac *DefaultAgentClient) getPipelineStatus(ctx context.Context, id string) (int, error) {
 	url := ac.httpUrl + "/pipelines/" + id
 	var obj map[string]interface{}
-	var res int;
+	var res int
 	err := ac.processRequest(ctx, url, func(body []byte, logAttrs log.Fields) error {
 		err := json.Unmarshal(body, &obj)
 		if err != nil {

--- a/agent_client.go
+++ b/agent_client.go
@@ -58,6 +58,13 @@ func (ac *DefaultAgentClient) getSubscriptions(ctx context.Context) ([]*Subscrip
 
 	result := []*Subscription{}
 	for _, subscription := range subscriptions {
+		subscription.isOpened = func() (bool, error) {
+			st, err := ac.getPipelineStatus(ctx, subscription.PipelineID)
+			if err != nil {
+				return false, err
+			}
+			return st == 4, nil
+		}
 		result = append(result, &subscription)
 	}
 	return result, nil

--- a/agent_client_test.go
+++ b/agent_client_test.go
@@ -17,7 +17,7 @@ func (dh *DummyHttp) Do(req *http.Request) (*http.Response, error) {
 	resp := `[{"pipeline":"pipeline01","subscription":"pipeline01-progress-subscription"}]`
 	return &http.Response{
 		StatusCode: 200,
-		Body: ioutil.NopCloser(strings.NewReader(resp)),
+		Body:       ioutil.NopCloser(strings.NewReader(resp)),
 	}, nil
 }
 

--- a/agent_client_test.go
+++ b/agent_client_test.go
@@ -16,6 +16,7 @@ type DummyHttp struct{}
 func (dh *DummyHttp) Do(req *http.Request) (*http.Response, error) {
 	resp := `[{"pipeline":"pipeline01","subscription":"pipeline01-progress-subscription"}]`
 	return &http.Response{
+		StatusCode: 200,
 		Body: ioutil.NopCloser(strings.NewReader(resp)),
 	}, nil
 }

--- a/pattern.go
+++ b/pattern.go
@@ -23,13 +23,24 @@ type Pattern struct {
 }
 
 func (p *Pattern) execute(msg *Message) error {
-	log.WithFields(log.Fields{"pattern": p}).Debugln("Executing command 0")
+	logAttrs := log.Fields{"pattern": p}
+	log.WithFields(logAttrs).Debugln("Executing command")
 	cmd, err := p.build(msg)
 	if err != nil {
+		logAttrs["error"] = err
+		log.WithFields(logAttrs).Errorln("Failed to build command")
 		return err
 	}
-	log.WithFields(log.Fields{"cmd": cmd}).Debugln("Executing command")
-	return cmd.Run()
+	logAttrs["cmd"] = cmd
+	log.WithFields(logAttrs).Debugln("Executing command")
+
+	err = cmd.Run()
+	if err != nil {
+		logAttrs["error"] = err
+		log.WithFields(logAttrs).Errorln("Command returned error")
+		return err
+	}
+	return nil
 }
 
 func (p *Pattern) match(msg *Message) bool {

--- a/process.go
+++ b/process.go
@@ -37,8 +37,12 @@ type Subscription struct {
 func (p *Process) execute(ctx context.Context) error {
 	subscriptions, err := p.agentApi.getSubscriptions(ctx)
 	if err != nil {
-		log.Errorln("Process.execute() err: ", err)
-		return err
+		switch err.(type) {
+		case *InvalidHttpResponse:
+			return nil
+		default:
+			return err
+		}
 	}
 	for _, sub := range subscriptions {
 		p.pullAndSave(ctx, sub)

--- a/process.go
+++ b/process.go
@@ -30,8 +30,10 @@ type Process struct {
 }
 
 type Subscription struct {
-	Pipeline string `json:"pipeline"`
-	Name     string `json:"subscription"`
+	PipelineID string `json:"pipeline_id"`
+	Pipeline   string `json:"pipeline"`
+	Name       string `json:"subscription"`
+	isOpened   func() (bool, error)
 }
 
 func (p *Process) execute(ctx context.Context) error {

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -75,24 +75,24 @@ func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscri
 }
 
 func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, receivedMessage *pubsub.ReceivedMessage, f func(msg *pubsub.ReceivedMessage) error) error {
-		err := f(receivedMessage)
-		if err == nil {
-			if _, err = ps.puller.Acknowledge(subscription.Name, receivedMessage.AckId); err != nil {
-				log.Infof("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
-				opened, err2 := subscription.isOpened()
-				if err2 != nil {
-					log.Errorf("Failed to check if the pipeline is alive because of [%T] %v for pipeline: %v", err2, err2, subscription.Pipeline)
-					return err2
-				} else if opened {
-					log.Errorf("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
-					return err
-				} else {
-					log.Infof("Skipping acknowledgement to pipeline: %v because the ipeline isn't opened.", subscription.Pipeline)
-				}
+	err := f(receivedMessage)
+	if err == nil {
+		if _, err = ps.puller.Acknowledge(subscription.Name, receivedMessage.AckId); err != nil {
+			log.Infof("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
+			opened, err2 := subscription.isOpened()
+			if err2 != nil {
+				log.Errorf("Failed to check if the pipeline is alive because of [%T] %v for pipeline: %v", err2, err2, subscription.Pipeline)
+				return err2
+			} else if opened {
+				log.Errorf("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
+				return err
+			} else {
+				log.Infof("Skipping acknowledgement to pipeline: %v because the ipeline isn't opened.", subscription.Pipeline)
 			}
-		} else {
-			log.Errorf("the received request process returns error: [%T] %v", err, err)
-			return err
 		}
-    return nil
+	} else {
+		log.Errorf("the received request process returns error: [%T] %v", err, err)
+		return err
+	}
+	return nil
 }

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -80,18 +80,18 @@ func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, rec
 		log.Errorf("the received request process returns error: [%T] %v", err, err)
 		return err
 	}
-		if _, err = ps.puller.Acknowledge(subscription.Name, receivedMessage.AckId); err != nil {
-			log.Infof("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
-			opened, err2 := subscription.isOpened()
-			if err2 != nil {
-				log.Errorf("Failed to check if the pipeline is alive because of [%T] %v for pipeline: %v", err2, err2, subscription.Pipeline)
-				return err2
-			} else if opened {
-				log.Errorf("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
-				return err
-			} else {
-				log.Infof("Skipping acknowledgement to pipeline: %v because the ipeline isn't opened.", subscription.Pipeline)
-			}
+	if _, err = ps.puller.Acknowledge(subscription.Name, receivedMessage.AckId); err != nil {
+		log.Infof("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
+		opened, err2 := subscription.isOpened()
+		if err2 != nil {
+			log.Errorf("Failed to check if the pipeline is alive because of [%T] %v for pipeline: %v", err2, err2, subscription.Pipeline)
+			return err2
+		} else if opened {
+			log.Errorf("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
+			return err
+		} else {
+			log.Infof("Skipping acknowledgement to pipeline: %v because the ipeline isn't opened.", subscription.Pipeline)
 		}
+	}
 	return nil
 }

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -66,6 +66,15 @@ func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscri
 		return err
 	}
 	for _, receivedMessage := range res.ReceivedMessages {
+		err := processProgressNotification(ctx, receivedMessage, f)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, receivedMessage *pubsub.ReceivedMessage, f func(msg *pubsub.ReceivedMessage) error) error {
 		err := f(receivedMessage)
 		if err == nil {
 			if _, err = ps.puller.Acknowledge(subscription.Name, receivedMessage.AckId); err != nil {
@@ -73,15 +82,17 @@ func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscri
 				opened, err2 := subscription.isOpened()
 				if err2 != nil {
 					log.Errorf("Failed to check if the pipeline is alive because of [%T] %v for pipeline: %v", err2, err2, subscription.Pipeline)
+					return err2
 				} else if opened {
 					log.Errorf("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
+					return err
 				} else {
 					log.Infof("Skipping acknowledgement to pipeline: %v because the ipeline isn't opened.", subscription.Pipeline)
 				}
 			}
 		} else {
 			log.Errorf("the received request process returns error: [%T] %v", err, err)
+			return err
 		}
-	}
-	return nil
+    return nil
 }

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -76,7 +76,10 @@ func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscri
 
 func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, receivedMessage *pubsub.ReceivedMessage, f func(msg *pubsub.ReceivedMessage) error) error {
 	err := f(receivedMessage)
-	if err == nil {
+	if err != nil {
+		log.Errorf("the received request process returns error: [%T] %v", err, err)
+		return err
+	}
 		if _, err = ps.puller.Acknowledge(subscription.Name, receivedMessage.AckId); err != nil {
 			log.Infof("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
 			opened, err2 := subscription.isOpened()
@@ -90,9 +93,5 @@ func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, rec
 				log.Infof("Skipping acknowledgement to pipeline: %v because the ipeline isn't opened.", subscription.Pipeline)
 			}
 		}
-	} else {
-		log.Errorf("the received request process returns error: [%T] %v", err, err)
-		return err
-	}
 	return nil
 }

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -66,7 +66,7 @@ func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscri
 		return err
 	}
 	for _, receivedMessage := range res.ReceivedMessages {
-		err := processProgressNotification(ctx, receivedMessage, f)
+		err := ps.processProgressNotification(ctx, subscription, receivedMessage, f)
 		if err != nil {
 			return err
 		}
@@ -74,7 +74,7 @@ func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscri
 	return nil
 }
 
-func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, receivedMessage *pubsub.ReceivedMessage, f func(msg *pubsub.ReceivedMessage) error) error {
+func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, subscription *Subscription, receivedMessage *pubsub.ReceivedMessage, f func(msg *pubsub.ReceivedMessage) error) error {
 	err := f(receivedMessage)
 	if err != nil {
 		log.Errorf("the received request process returns error: [%T] %v", err, err)

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -85,13 +85,21 @@ func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, sub
 		log.Infof("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
 		opened, err2 := subscription.isOpened()
 		if err2 != nil {
+			switch err2.(type) {
+			case *InvalidHttpResponse:
+				e := err2.(*InvalidHttpResponse)
+				if e.StatusCode == 404 {
+					log.Infof("Skipping acknowledgement to pipeline: %v because the pipeline must be removed", subscription.Pipeline)
+					return nil
+				}
+			}
 			log.Errorf("Failed to check if the pipeline is opened because of [%T] %v for pipeline: %v", err2, err2, subscription.Pipeline)
 			return err2
 		} else if opened {
 			log.Errorf("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
 			return err
 		} else {
-			log.Infof("Skipping acknowledgement to pipeline: %v because the ipeline isn't opened.", subscription.Pipeline)
+			log.Infof("Skipping acknowledgement to pipeline: %v because the pipeline isn't opened.", subscription.Pipeline)
 		}
 	}
 	return nil

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -62,17 +62,25 @@ func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscri
 	}
 	res, err := ps.puller.Pull(subscription.Name, pullRequest)
 	if err != nil {
-		log.Errorf("Failed to pull: %v\n", err)
+		log.Errorf("Failed to pull: [%T] %v\n", err, err)
 		return err
 	}
 	for _, receivedMessage := range res.ReceivedMessages {
 		err := f(receivedMessage)
 		if err == nil {
 			if _, err = ps.puller.Acknowledge(subscription.Name, receivedMessage.AckId); err != nil {
-				log.Fatalf("Failed to acknowledge for message: %v cause of %v", receivedMessage, err)
+				log.Infof("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
+				opened, err2 := subscription.isOpened()
+				if err2 != nil {
+					log.Errorf("Failed to check if the pipeline is alive because of [%T] %v for pipeline: %v", err2, err2, subscription.Pipeline)
+				} else if opened {
+					log.Errorf("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
+				} else {
+					log.Infof("Skipping acknowledgement to pipeline: %v because the ipeline isn't opened.", subscription.Pipeline)
+				}
 			}
 		} else {
-			log.Errorf("the received request process returns error: %v", err)
+			log.Errorf("the received request process returns error: [%T] %v", err, err)
 		}
 	}
 	return nil

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -85,7 +85,7 @@ func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, sub
 		log.Infof("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
 		opened, err2 := subscription.isOpened()
 		if err2 != nil {
-			log.Errorf("Failed to check if the pipeline is alive because of [%T] %v for pipeline: %v", err2, err2, subscription.Pipeline)
+			log.Errorf("Failed to check if the pipeline is opened because of [%T] %v for pipeline: %v", err2, err2, subscription.Pipeline)
 			return err2
 		} else if opened {
 			log.Errorf("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -100,6 +100,7 @@ func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, sub
 			return err
 		} else {
 			log.Infof("Skipping acknowledgement to pipeline: %v because the pipeline isn't opened.", subscription.Pipeline)
+			return nil
 		}
 	}
 	return nil

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -80,7 +80,8 @@ func (ps *PubsubSubscriber) processProgressNotification(ctx context.Context, rec
 		log.Errorf("the received request process returns error: [%T] %v", err, err)
 		return err
 	}
-	if _, err = ps.puller.Acknowledge(subscription.Name, receivedMessage.AckId); err != nil {
+	_, err = ps.puller.Acknowledge(subscription.Name, receivedMessage.AckId)
+	if err != nil {
 		log.Infof("Failed to acknowledge for message: %v cause of [%T] %v", receivedMessage, err, err)
 		opened, err2 := subscription.isOpened()
 		if err2 != nil {

--- a/pubsub_subscriber_test.go
+++ b/pubsub_subscriber_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	pubsub "google.golang.org/api/pubsub/v1"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+type DummyPuller struct {
+	Error   error
+	PullRes *pubsub.PullResponse
+	AckRes  *pubsub.Empty
+}
+
+func (dp *DummyPuller) Pull(subscription string, pullrequest *pubsub.PullRequest) (*pubsub.PullResponse, error) {
+	if dp.Error != nil {
+		return nil, dp.Error
+	}
+	res := dp.PullRes
+	if res == nil {
+		res = &pubsub.PullResponse{}
+	}
+	return dp.PullRes, nil
+}
+
+func (dp *DummyPuller) Acknowledge(subscription, ackId string) (*pubsub.Empty, error) {
+	if dp.Error != nil {
+		return nil, dp.Error
+	}
+	res := dp.AckRes
+	if res == nil {
+		res = &pubsub.Empty{}
+	}
+	return dp.AckRes, nil
+}
+
+func TestProcessProgressNotification(t *testing.T) {
+	ctx := context.Background()
+
+	dp := &DummyPuller{}
+
+	ps := PubsubSubscriber{
+		MessagePerPull: 1,
+		puller:         dp,
+	}
+
+	subscription := &Subscription{
+		PipelineID: "pipeline0123456789",
+		Pipeline:   "dummy-pipeline01",
+		Name:       "dummy-pipeline01-progress-subscription",
+	}
+
+	recvMsg := &pubsub.ReceivedMessage{
+		AckId: "dummy-ack-id",
+	}
+
+	returnNil := func(msg *pubsub.ReceivedMessage) error {
+		return nil
+	}
+
+	returnError := func(msg *pubsub.ReceivedMessage) error {
+		return fmt.Errorf("Dummy Error")
+	}
+
+	// Normal pattern
+	err := ps.processProgressNotification(ctx, subscription, recvMsg, returnNil)
+	assert.NoError(t, err)
+
+	//  f returns an error
+	err = ps.processProgressNotification(ctx, subscription, recvMsg, returnError)
+	assert.Error(t, err)
+	assert.Equal(t, "Dummy Error", err.Error())
+
+	// Ack error and fail to get pipeline status
+	dp.Error = fmt.Errorf("ack-error")
+	subscription.isOpened = func() (bool, error) {
+		return false, fmt.Errorf("pipeline status error")
+	}
+	err = ps.processProgressNotification(ctx, subscription, recvMsg, returnNil)
+	assert.Error(t, err)
+
+	// Ack error and fail to get pipeline status
+	dp.Error = fmt.Errorf("ack-error")
+	subscription.isOpened = func() (bool, error) {
+		return true, nil // opened
+	}
+	err = ps.processProgressNotification(ctx, subscription, recvMsg, returnNil)
+	assert.Error(t, err)
+
+	// Ack error and fail to get pipeline status
+	dp.Error = fmt.Errorf("ack-error")
+	subscription.isOpened = func() (bool, error) {
+		return false, nil // closing
+	}
+	err = ps.processProgressNotification(ctx, subscription, recvMsg, returnNil)
+	assert.NoError(t, err)
+}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.0.4"
+const VERSION = "0.0.5"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.0.3"
+const VERSION = "0.0.4"


### PR DESCRIPTION
## Overview

Change the behavior to ignore acknowledge error after the pipeline is closed/deleted.

Ignore ack error in the following situation:
- the pipeilne is being closed or already closed
- the pipeilne is deleted


## Background

`pub/sub` doesn't always deliver messages in the same order as it receives.
A message `completed` is sometimes received before a message `starting` is received.
An acknowledge error should be ignored after the pipeline is closed or deleted because the pipeline is automatically closed on `completed` notification message.

