### PR TITLE
Update pipeline_jobs.updated_at

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ blocks-concurrent-subscriber \
 `datasource` must be a string to connect your MySQL database like this:
 
 ```
-"user:password@/dbname"
+"user:password@/dbname?parseTime=true"
 ```
 
 See https://github.com/go-sql-driver/mysql#usage for more detail.

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -77,7 +77,7 @@ $ mysql -u root blocks_subscriber_example1 < migrations/up.sql
 
 ```json
 {
-  "datasource": "root:@/blocks_subscriber_example1",
+  "datasource": "root:@/blocks_subscriber_example1?parseTime=true",
   "agent-root-url": "[the token you got before]",
   "agent-root-token": "[the host name you deployed]",
   "interval": 10,

--- a/migrations/up.sql
+++ b/migrations/up.sql
@@ -3,6 +3,8 @@ CREATE TABLE `pipeline_jobs` (
   `pipeline` varchar(255) NOT NULL,
   `job_message_id` varchar(255) DEFAULT NULL,
   `progress` int(11) NOT NULL,
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/progress_store.go
+++ b/progress_store.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"runtime"
+	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 
@@ -12,7 +13,7 @@ import (
 )
 
 const (
-	SQL_UPDATE_JOBS = "UPDATE pipeline_jobs SET progress = ? WHERE job_message_id = ? AND progress < ?"
+	SQL_UPDATE_JOBS = "UPDATE pipeline_jobs SET progress = ?, updated_at = ? WHERE job_message_id = ? AND progress < ?"
 	SQL_INSERT_LOGS = "INSERT INTO pipeline_job_logs (pipeline, job_message_id, publish_time, progress, completed, log_level, log_message) VALUES (?, ?, ?, ?, ?, ?, ?)"
 )
 
@@ -35,7 +36,7 @@ func (ss *SqlStore) save(ctx context.Context, pipeline string, msg *Message, f f
 	logAttrs := log.Fields(msg.buildMap())
 	err := ss.transaction(func(tx *sql.Tx) error {
 		logAttrs["SQL"] = SQL_UPDATE_JOBS
-		_, err := tx.Exec(SQL_UPDATE_JOBS, msg.progress, msg.msg_id, msg.progress)
+		_, err := tx.Exec(SQL_UPDATE_JOBS, msg.progress, time.Now(), msg.msg_id, msg.progress)
 		if err != nil {
 			logAttrs["error"] = err
 			log.WithFields(logAttrs).Errorln("Failed to update pipeline_jobs")

--- a/progress_store_test.go
+++ b/progress_store_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	TEST_DATASOURCE = "root:@/blocks_subscriber_test"
+	TEST_DATASOURCE = "root:@/blocks_subscriber_test?parseTime=true"
 )
 
 func assertCount(t *testing.T, db *sql.DB, expected int, sql string, args ...interface{}) bool {

--- a/progress_store_test.go
+++ b/progress_store_test.go
@@ -83,12 +83,13 @@ func TestProgressStoreSave(t *testing.T) {
 	assert.Equal(t, 1, pl.progress)
 	assert.Equal(t, pl.created_at.UnixNano(), pl.updated_at.UnixNano())
 
+	time.Sleep(100 * time.Millisecond) // To make difference between updated_at and created_at
 	store.save(ctx, "pipeline01", msg, extra)
 
 	pl, err = queryPipelineJob(db, "WHERE pipeline='pipeline01' AND job_message_id=?", msg.msg_id)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, pl.progress)
-	assert.True(t, pl.created_at.UnixNano() != pl.updated_at.UnixNano())
+	assert.NotEqual(t, pl.created_at.UnixNano(), pl.updated_at.UnixNano())
 
 	msg = &Message{
 		msg_id:      "jm04",

--- a/progress_store_test.go
+++ b/progress_store_test.go
@@ -83,7 +83,7 @@ func TestProgressStoreSave(t *testing.T) {
 	assert.Equal(t, 1, pl.progress)
 	assert.Equal(t, pl.created_at.UnixNano(), pl.updated_at.UnixNano())
 
-	time.Sleep(100 * time.Millisecond) // To make difference between updated_at and created_at
+	time.Sleep(1 * time.Second) // To make difference between updated_at and created_at
 	store.save(ctx, "pipeline01", msg, extra)
 
 	pl, err = queryPipelineJob(db, "WHERE pipeline='pipeline01' AND job_message_id=?", msg.msg_id)

--- a/test/config1.json
+++ b/test/config1.json
@@ -1,5 +1,5 @@
 {
-  "datasource": "root:@/database1",
+  "datasource": "root:@/database1?parseTime=true",
   "agent-root-url": "https://blocks-concurrent-batch-agent-somewhere.com",
   "agent-root-token": "password1",
   "message-per-pull": 100,

--- a/test/setup.sql
+++ b/test/setup.sql
@@ -1,16 +1,16 @@
 DELETE FROM pipeline_jobs;
 INSERT INTO pipeline_jobs
-  (pipeline, job_message_id, progress)
+  (pipeline, job_message_id, progress, created_at, updated_at)
   VALUES
-  ('pipeline01', 'jm01', 1),
-  ('pipeline01', 'jm02', 2),
-  ('pipeline01', 'jm03', 3),
-  ('pipeline01', 'jm04', 4),
-  ('pipeline01', 'jm05', 5),
-  ('pipeline02', 'jm01', 1),
-  ('pipeline02', 'jm02', 2),
-  ('pipeline02', 'jm03', 3),
-  ('pipeline02', 'jm04', 4),
-  ('pipeline02', 'jm05', 5);
+  ('pipeline01', 'jm01', 1, now(), now()),
+  ('pipeline01', 'jm02', 2, now(), now()),
+  ('pipeline01', 'jm03', 3, now(), now()),
+  ('pipeline01', 'jm04', 4, now(), now()),
+  ('pipeline01', 'jm05', 5, now(), now()),
+  ('pipeline02', 'jm01', 1, now(), now()),
+  ('pipeline02', 'jm02', 2, now(), now()),
+  ('pipeline02', 'jm03', 3, now(), now()),
+  ('pipeline02', 'jm04', 4, now(), now()),
+  ('pipeline02', 'jm05', 5, now(), now());
 
 DELETE FROM pipeline_job_logs;

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.0.5"
+const VERSION = "0.1.0"


### PR DESCRIPTION
This PR is for #7 .

Add `created_at` and `updated_at` to `pipeline_jobs` table in order to calculate durations for each jobs.
`blocks-concurrent-subscriber` updates `pipeline_jobs.updated_at` too.

Now `pipeline_jobs` table must allow to run the following SQL:

```sql
UPDATE pipeline_jobs SET progress = ?, updated_at = ? WHERE job_message_id = ? AND progress < ?
```

The actual code is [here](https://github.com/groovenauts/blocks-concurrent-subscriber/blob/39e930a67575db88a7c4942bac2038aa19255866/progress_store.go#L16)
