### PR TITLE
Create GitHub Release by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,17 @@ before_script:
   - make check
 script:
   - go test
+before_deploy:
+  - make build
+deploy:
+  provider: releases
+  api_key:
+    secure: bALyIitlApWkD9ymSugf3mZFdpmsv/GMppBn6IZUKzzBzNsP5L0XcfJh0jta3/oYf0E8PoPLKBlbjPFifn916noPdZGXDkeJSFwmOs4EEC90HCIGVb6q/2ia5jrDYYGB7IcmjyL9d6MNuHU4NUIkMwqzFIcnRuMt9son4nxfv0yhO+qyQjbkJUkJD69lfCf0NEYeM0o2NUu+IUPdAC8rDE+Q+NL1aOQNh/AwCYHHHN5yZpf88ijWiWbNpbyRIwdOPZo+SNPZSsYioru9fPhWmqhcKbehm0m7Hfxa99rWOTM9eKKRMCX2G4splBz2Noh7YLJX205Cj5rxeBEMsD9KSPpJK7ZuNn3PQbnDZomxdA6W/a5AWwCfDRSSpTNI2np5zQ/vEE5JPwC+e6hlD+RxJr82ohfyx14DWxJcabU2wR2l/A+Py/8Q7r2eLuQZr7YvQBRZvL3vIUXgARlqh1zcJaivxmc6jBbMt5zYJOEHulkmnp31aASxd7uuz5GgHb3mafbzj114Wdsp3m0TTNdOxxcb4ngiDfTDl70WuGJcIxNhEqqCUNg1OfrBr5O/9fVdvWev9EIZ46q54MHQu8aeUrL/bAYCEHo2zXiW7N1IhQwzJPYNpCsUoPli9Jm6x0I0XEZ0tP83+u3PY2PQvMMCnDmSCZwp1v4sIBrzkgCD68s=
+  file:
+    - pkg/blocks-concurrent-subscriber_darwin_amd64
+    - pkg/blocks-concurrent-subscriber_linux_amd64
+  skip_cleanup: true
+  on:
+    repo: groovenauts/blocks-concurrent-subscriber
+    tags: true
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_script:
 script:
   - go test
 before_deploy:
+  - make setup
   - make build
 deploy:
   provider: releases

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ all: build
 
 setup:
 	go get github.com/mitchellh/gox
-	go get github.com/tcnksm/ghr
 
 checksetup:
 	go get golang.org/x/tools/cmd/goimports
@@ -42,12 +41,6 @@ build:
 	for x in "$(OS_LIST)" ; do \
 		gox -output="${PKGDIR}/{{.Dir}}_{{.OS}}_{{.Arch}}" -os="$$x" -arch="${ARCH}" ; \
 	done
-
-release: build
-	ghr -u groovenauts -r blocks-concurrent-subscriber --replace --draft ${VERSION} pkg
-
-prerelease: build
-	ghr -u groovenauts -r blocks-concurrent-subscriber --replace --draft --prerelease ${VERSION} pkg
 
 version:
 	echo ${VERSION}


### PR DESCRIPTION
You can release binaries by pushing tag

```shell
git tag a_tag_name [branch_or_commit]
git push origin a_tag_name
```

or creating release https://github.com/groovenauts/blocks-concurrent-subscriber/releases/new

Then Travis CI will build binaries and put them as release assets

![image](https://cloud.githubusercontent.com/assets/162862/25515103/2ebfdf82-2c1d-11e7-8989-a1d032c9ab38.png)

See also:
- https://docs.travis-ci.com/user/deployment
- https://docs.travis-ci.com/user/deployment/releases
