### PR TITLE
Build docker image with automated build on Docker Hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+pkg/
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ deploy:
       repo: groovenauts/blocks-concurrent-subscriber
       tags: true
   - provider: script
+    # To download release assets (pre-built binary) in Docker Hub,
+    # Docker Hub automated build should be triggered after `provider: releases`
     script: scripts/release-docker-image.sh
     on:
       repo: groovenauts/blocks-concurrent-subscriber

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,19 @@ before_deploy:
   - make setup
   - make build
 deploy:
-  provider: releases
-  api_key:
-    secure: bALyIitlApWkD9ymSugf3mZFdpmsv/GMppBn6IZUKzzBzNsP5L0XcfJh0jta3/oYf0E8PoPLKBlbjPFifn916noPdZGXDkeJSFwmOs4EEC90HCIGVb6q/2ia5jrDYYGB7IcmjyL9d6MNuHU4NUIkMwqzFIcnRuMt9son4nxfv0yhO+qyQjbkJUkJD69lfCf0NEYeM0o2NUu+IUPdAC8rDE+Q+NL1aOQNh/AwCYHHHN5yZpf88ijWiWbNpbyRIwdOPZo+SNPZSsYioru9fPhWmqhcKbehm0m7Hfxa99rWOTM9eKKRMCX2G4splBz2Noh7YLJX205Cj5rxeBEMsD9KSPpJK7ZuNn3PQbnDZomxdA6W/a5AWwCfDRSSpTNI2np5zQ/vEE5JPwC+e6hlD+RxJr82ohfyx14DWxJcabU2wR2l/A+Py/8Q7r2eLuQZr7YvQBRZvL3vIUXgARlqh1zcJaivxmc6jBbMt5zYJOEHulkmnp31aASxd7uuz5GgHb3mafbzj114Wdsp3m0TTNdOxxcb4ngiDfTDl70WuGJcIxNhEqqCUNg1OfrBr5O/9fVdvWev9EIZ46q54MHQu8aeUrL/bAYCEHo2zXiW7N1IhQwzJPYNpCsUoPli9Jm6x0I0XEZ0tP83+u3PY2PQvMMCnDmSCZwp1v4sIBrzkgCD68s=
-  file:
-    - pkg/blocks-concurrent-subscriber_darwin_amd64
-    - pkg/blocks-concurrent-subscriber_linux_amd64
-  skip_cleanup: true
-  on:
-    repo: groovenauts/blocks-concurrent-subscriber
-    tags: true
+  - provider: releases
+    api_key:
+      secure: bALyIitlApWkD9ymSugf3mZFdpmsv/GMppBn6IZUKzzBzNsP5L0XcfJh0jta3/oYf0E8PoPLKBlbjPFifn916noPdZGXDkeJSFwmOs4EEC90HCIGVb6q/2ia5jrDYYGB7IcmjyL9d6MNuHU4NUIkMwqzFIcnRuMt9son4nxfv0yhO+qyQjbkJUkJD69lfCf0NEYeM0o2NUu+IUPdAC8rDE+Q+NL1aOQNh/AwCYHHHN5yZpf88ijWiWbNpbyRIwdOPZo+SNPZSsYioru9fPhWmqhcKbehm0m7Hfxa99rWOTM9eKKRMCX2G4splBz2Noh7YLJX205Cj5rxeBEMsD9KSPpJK7ZuNn3PQbnDZomxdA6W/a5AWwCfDRSSpTNI2np5zQ/vEE5JPwC+e6hlD+RxJr82ohfyx14DWxJcabU2wR2l/A+Py/8Q7r2eLuQZr7YvQBRZvL3vIUXgARlqh1zcJaivxmc6jBbMt5zYJOEHulkmnp31aASxd7uuz5GgHb3mafbzj114Wdsp3m0TTNdOxxcb4ngiDfTDl70WuGJcIxNhEqqCUNg1OfrBr5O/9fVdvWev9EIZ46q54MHQu8aeUrL/bAYCEHo2zXiW7N1IhQwzJPYNpCsUoPli9Jm6x0I0XEZ0tP83+u3PY2PQvMMCnDmSCZwp1v4sIBrzkgCD68s=
+    file:
+      - pkg/blocks-concurrent-subscriber_darwin_amd64
+      - pkg/blocks-concurrent-subscriber_linux_amd64
+    skip_cleanup: true
+    on:
+      repo: groovenauts/blocks-concurrent-subscriber
+      tags: true
+  - provider: script
+    script: scripts/release-docker-image.sh
+    on:
+      repo: groovenauts/blocks-concurrent-subscriber
+      tags: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:jessie
+
+ARG version=v0.2.0
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    apt-get clean
+
+ADD https://github.com/groovenauts/blocks-concurrent-subscriber/releases/download/${version}/blocks-concurrent-subscriber_linux_amd64 \
+    /blocks-concurrent-subscriber
+
+RUN chmod +x /blocks-concurrent-subscriber
+
+CMD /blocks-concurrent-subscriber

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-ARG version=v0.2.1
+ARG version=0.2.1
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie
 
-ARG version=v0.2.0
+ARG version=v0.2.1
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \

--- a/README.md
+++ b/README.md
@@ -81,3 +81,16 @@ $ blocks-concurrent-subscriber -c config.json
   ]
 }
 ```
+
+## Docker image
+
+Docker image [groovenauts/blocks-concurrent-subscriber](https://hub.docker.com/r/groovenauts/blocks-concurrent-subscriber) is available.
+
+```shell
+docker pull groovenauts/blocks-concurrent-subscriber:${TAG}
+docker run -v /path/to/config.json:/config.json groovenauts/blocks-concurrent-subscriber:${TAG} /blocks-concurrent-subscriber -c /config.json
+```
+
+About available `${TAG}`, see https://hub.docker.com/r/groovenauts/blocks-concurrent-subscriber/tags/
+
+

--- a/scripts/release-docker-image.sh
+++ b/scripts/release-docker-image.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+# Trigger Docker Hub automated build
+# https://docs.docker.com/docker-hub/builds/#remote-build-triggers
+
+curl -H "Content-Type: application/json" \
+     --data "{\"source_type\": \"Tag\", \"source_name\": \"${TRAVIS_TAG}\"}" \
+     -X POST \
+     https://registry.hub.docker.com/u/groovenauts/blocks-concurrent-subscriber/trigger/${DOCKER_HUB_TRIGGER_TOKEN}/
+

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.0"
+const VERSION = "0.2.1"


### PR DESCRIPTION
 Closes #13

When you push git tag, Travis CI will build binary, create GitHub release with assets, 
then trigger Docker Hub automated build with tag name.

After this PR is merged, I will push git tag `0.2.1` (not `v0.2.1`)

----

Configuration memo.

* Docker Hub
  * Created [groovenauts/blocks-concurrent-subscriber](https://hub.docker.com/r/groovenauts/blocks-concurrent-subscriber) repository, as public, automated build repository.
  * Configured [Build Settings](https://hub.docker.com/r/groovenauts/blocks-concurrent-subscriber/~/settings/automated-builds/)
    * Removed `When active, builds will happen automatically on pushes.` check
    * Only build image with git tags ![image](https://cloud.githubusercontent.com/assets/162862/26299074/705c0d94-3f14-11e7-9b0b-e6bc886e147d.png)
    * Enabled build trigger (ref: https://docs.docker.com/docker-hub/builds/#remote-build-triggers)

* Travis CI
  * Added environment variable `DOCKER_HUB_TRIGGER_TOKEN` in [Repository Settings](https://travis-ci.org/groovenauts/blocks-concurrent-subscriber/settings) (ref: https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings)
