### PR TITLE
Improve pulling time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ build:
 		gox -output="${PKGDIR}/{{.Dir}}_{{.OS}}_{{.Arch}}" -os="$$x" -arch="${ARCH}" ; \
 	done
 
+
+release: build
+	ghr -u groovenauts -r ${BASENAME} --replace --draft ${VERSION} pkg
+
+prerelease: build
+	ghr -u groovenauts -r ${BASENAME} --replace --draft --prerelease ${VERSION} pkg
+
 version:
 	echo ${VERSION}
 

--- a/main.go
+++ b/main.go
@@ -39,6 +39,11 @@ func executeCommand(c *cli.Context) error {
 		os.Exit(1)
 	}
 
+	formatter := new(log.TextFormatter)
+	formatter.TimestampFormat = "2006-01-02 15:04:05 -0700"
+	formatter.FullTimestamp = true
+	log.SetFormatter(formatter)
+
 	level, err := log.ParseLevel(config.LogLevel)
 	if err != nil {
 		fmt.Printf("Invalid log level %v cause of %v\n", config.LogLevel, err)

--- a/process.go
+++ b/process.go
@@ -54,7 +54,6 @@ func (p *Process) execute(ctx context.Context) error {
 		}
 		targets = append(targets, subsFromAgent...)
 	}
-	log.WithFields(log.Fields{"subscriptions": targets}).Debugln("Pulling")
 	for _, sub := range targets {
 		p.pullAndSave(ctx, sub)
 	}

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -66,6 +66,7 @@ func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscri
 		log.Errorf("Failed to pull: [%T] %v\n", err, err)
 		return err
 	}
+	log.WithFields(log.Fields{"subscription": subscription.Name}).Debugln("Pulled successfully")
 	for _, receivedMessage := range res.ReceivedMessages {
 		err := ps.processProgressNotification(ctx, subscription, receivedMessage, f)
 		if err != nil {

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -57,7 +57,7 @@ func (ps *PubsubSubscriber) setup(ctx context.Context) error {
 
 func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscription, f func(msg *pubsub.ReceivedMessage) error) error {
 	pullRequest := &pubsub.PullRequest{
-		ReturnImmediately: false,
+		ReturnImmediately: true,
 		MaxMessages:       ps.MessagePerPull,
 	}
 	log.WithFields(log.Fields{"subscription": subscription.Name}).Debugln("Pulling")

--- a/pubsub_subscriber.go
+++ b/pubsub_subscriber.go
@@ -60,6 +60,7 @@ func (ps *PubsubSubscriber) subscribe(ctx context.Context, subscription *Subscri
 		ReturnImmediately: false,
 		MaxMessages:       ps.MessagePerPull,
 	}
+	log.WithFields(log.Fields{"subscription": subscription.Name}).Debugln("Pulling")
 	res, err := ps.puller.Pull(subscription.Name, pullRequest)
 	if err != nil {
 		log.Errorf("Failed to pull: [%T] %v\n", err, err)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.1"
+const VERSION = "0.2.2-alpha1"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.2-alpha1"
+const VERSION = "0.2.2"


### PR DESCRIPTION
Improve pulling time by setting `RetrurnImmediately` `true`.
The pulling time got changed from about 90 seconds to about 1.5 seconds.

### RetrurnImmediately

```
If this field set to true, the system will respond immediately even if it there are
 no messages available to return in the subscriptions.pull response. Otherwise,
 the system may wait (for a bounded amount of time) until at least one message
 is available, rather than returning no messages. The client may cancel the request
 if it does not wish to wait any longer for the response.
```

https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull#request-body


## Other changes

- Use log formatter with `FullTimestamp`
- Add logging for debug
- Add make tasks `release` and `prerelease`
