### PR TITLE
Fix DefaultAgentClient#getSubscriptions

### DIFF
--- a/agent_client.go
+++ b/agent_client.go
@@ -73,8 +73,12 @@ func (ac *DefaultAgentClient) convertToSubscriptionPointerArray(ctx context.Cont
 	}
 
 	result := []*Subscription{}
-	for _, subscription := range subscriptions {
-		sub := &subscription
+	for _, s := range subscriptions {
+		sub := &Subscription{
+			PipelineID: s.PipelineID,
+			Pipeline  : s.Pipeline,
+			Name      : s.Name,
+		}
 		sub.isOpened = func() (bool, error) {
 			st, err := ac.getPipelineStatus(ctx, sub.PipelineID)
 			if err != nil {

--- a/agent_client.go
+++ b/agent_client.go
@@ -59,6 +59,10 @@ func (ac *DefaultAgentClient) getSubscriptions(ctx context.Context) ([]*Subscrip
 		return nil, err
 	}
 
+	return ac.convertToSubscriptionPointerArray(ctx, subscriptions), nil
+}
+
+func (ac *DefaultAgentClient) convertToSubscriptionPointerArray(ctx context.Context, subscriptions []Subscription) []*Subscription {
 	for idx, sub := range subscriptions {
 		fields := log.Fields{
 			"PipelineID": sub.PipelineID,
@@ -90,7 +94,7 @@ func (ac *DefaultAgentClient) getSubscriptions(ctx context.Context) ([]*Subscrip
 		log.WithFields(fields).Debugf("Client getSubscriptions result %v\n", idx)
 	}
 
-	return result, nil
+	return result
 }
 
 func (ac *DefaultAgentClient) getPipelineStatus(ctx context.Context, id string) (int, error) {

--- a/agent_client.go
+++ b/agent_client.go
@@ -76,8 +76,8 @@ func (ac *DefaultAgentClient) convertToSubscriptionPointerArray(ctx context.Cont
 	for _, s := range subscriptions {
 		sub := &Subscription{
 			PipelineID: s.PipelineID,
-			Pipeline  : s.Pipeline,
-			Name      : s.Name,
+			Pipeline:   s.Pipeline,
+			Name:       s.Name,
 		}
 		sub.isOpened = func() (bool, error) {
 			st, err := ac.getPipelineStatus(ctx, sub.PipelineID)

--- a/agent_client.go
+++ b/agent_client.go
@@ -59,17 +59,37 @@ func (ac *DefaultAgentClient) getSubscriptions(ctx context.Context) ([]*Subscrip
 		return nil, err
 	}
 
+	for idx, sub := range subscriptions {
+		fields := log.Fields{
+			"PipelineID": sub.PipelineID,
+			"Pipeline":   sub.Pipeline,
+			"Name":       sub.Name,
+		}
+		log.WithFields(fields).Debugf("Client Recceived Subscription %v\n", idx)
+	}
+
 	result := []*Subscription{}
 	for _, subscription := range subscriptions {
-		subscription.isOpened = func() (bool, error) {
-			st, err := ac.getPipelineStatus(ctx, subscription.PipelineID)
+		sub := &subscription
+		sub.isOpened = func() (bool, error) {
+			st, err := ac.getPipelineStatus(ctx, sub.PipelineID)
 			if err != nil {
 				return false, err
 			}
 			return st == 4, nil
 		}
-		result = append(result, &subscription)
+		result = append(result, sub)
 	}
+
+	for idx, sub := range result {
+		fields := log.Fields{
+			"PipelineID": sub.PipelineID,
+			"Pipeline":   sub.Pipeline,
+			"Name":       sub.Name,
+		}
+		log.WithFields(fields).Debugf("Client getSubscriptions result %v\n", idx)
+	}
+
 	return result, nil
 }
 

--- a/agent_client_test.go
+++ b/agent_client_test.go
@@ -37,3 +37,20 @@ func TestGetSubscriptions(t *testing.T) {
 	assert.Equal(t, "pipeline01", sub.Pipeline)
 	assert.Equal(t, "pipeline01-progress-subscription", sub.Name)
 }
+
+func TestConvertToSubscriptionPointerArray(t *testing.T) {
+	ctx := context.Background()
+	s1 := Subscription{ Name: "sub1"}
+	s2 := Subscription{ Name: "sub2" }
+	s3 := Subscription{ Name: "sub3" }
+	subscriptions := []Subscription{s1, s2, s3}
+
+	ac := &DefaultAgentClient{}
+
+	res := ac.convertToSubscriptionPointerArray(ctx, subscriptions)
+	assert.Equal(t, len(subscriptions), len(res))
+
+	assert.Equal(t, "sub1", res[0].Name)
+	assert.Equal(t, "sub2", res[1].Name)
+	assert.Equal(t, "sub3", res[2].Name)
+}

--- a/agent_client_test.go
+++ b/agent_client_test.go
@@ -40,9 +40,9 @@ func TestGetSubscriptions(t *testing.T) {
 
 func TestConvertToSubscriptionPointerArray(t *testing.T) {
 	ctx := context.Background()
-	s1 := Subscription{ Name: "sub1"}
-	s2 := Subscription{ Name: "sub2" }
-	s3 := Subscription{ Name: "sub3" }
+	s1 := Subscription{Name: "sub1"}
+	s2 := Subscription{Name: "sub2"}
+	s3 := Subscription{Name: "sub3"}
 	subscriptions := []Subscription{s1, s2, s3}
 
 	ac := &DefaultAgentClient{}

--- a/process.go
+++ b/process.go
@@ -54,6 +54,14 @@ func (p *Process) execute(ctx context.Context) error {
 		}
 		targets = append(targets, subsFromAgent...)
 	}
+	for idx, sub := range targets {
+		fields := log.Fields{
+			"PipelineID": sub.PipelineID,
+			"Pipeline"  : sub.Pipeline,
+			"Name"      : sub.Name,
+		}
+		log.WithFields(fields).Debugf("Received Subscription %v\n", idx)
+	}
 	for _, sub := range targets {
 		p.pullAndSave(ctx, sub)
 	}
@@ -61,10 +69,19 @@ func (p *Process) execute(ctx context.Context) error {
 }
 
 func (p *Process) pullAndSave(ctx context.Context, subscription *Subscription) error {
+	fields := log.Fields{
+		"PipelineID": subscription.PipelineID,
+		"Pipeline"  : subscription.Pipeline,
+		"Name"      : subscription.Name,
+	}
+	log.WithFields(fields).Debugln("Subscribing...")
 	err := p.subscriber.subscribe(ctx, subscription, func(recvMsg *pubsub.ReceivedMessage) error {
 		m := recvMsg.Message
 
-		fields := log.Fields{}
+		fields := log.Fields{
+			"MessageId": m.MessageId,
+			"PublishTime": m.PublishTime,
+		}
 		for k, v := range m.Attributes {
 			fields[k] = v
 		}

--- a/process.go
+++ b/process.go
@@ -57,8 +57,8 @@ func (p *Process) execute(ctx context.Context) error {
 	for idx, sub := range targets {
 		fields := log.Fields{
 			"PipelineID": sub.PipelineID,
-			"Pipeline"  : sub.Pipeline,
-			"Name"      : sub.Name,
+			"Pipeline":   sub.Pipeline,
+			"Name":       sub.Name,
 		}
 		log.WithFields(fields).Debugf("Received Subscription %v\n", idx)
 	}
@@ -71,15 +71,15 @@ func (p *Process) execute(ctx context.Context) error {
 func (p *Process) pullAndSave(ctx context.Context, subscription *Subscription) error {
 	fields := log.Fields{
 		"PipelineID": subscription.PipelineID,
-		"Pipeline"  : subscription.Pipeline,
-		"Name"      : subscription.Name,
+		"Pipeline":   subscription.Pipeline,
+		"Name":       subscription.Name,
 	}
 	log.WithFields(fields).Debugln("Subscribing...")
 	err := p.subscriber.subscribe(ctx, subscription, func(recvMsg *pubsub.ReceivedMessage) error {
 		m := recvMsg.Message
 
 		fields := log.Fields{
-			"MessageId": m.MessageId,
+			"MessageId":   m.MessageId,
 			"PublishTime": m.PublishTime,
 		}
 		for k, v := range m.Attributes {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.3-alpha2"
+const VERSION = "0.2.3-alpha3"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.3-alpha1"
+const VERSION = "0.2.3"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.3"
+const VERSION = "0.2.3-alpha2"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.2.2"
+const VERSION = "0.2.3-alpha1"


### PR DESCRIPTION
Fix `DefaultAgentClient#getSubscriptions`.

## Bug

Old version gets subscriptions from `blocks-concurrent-batch-agent` and returns a subscription pointer array which has the same length as original subscriptions but all of the elements is the same value.

### example

- subscriptions from `blocks-concurrent-batch-agent`
    - sub1
    - sub2
    - sub3
- `DefaultAgentClient#getSubscriptions` result
    - sub3
    - sub3
    - sub3

## Fix

Allocate new Subscription struct for result of `DefaultAgentClient#getSubscriptions`

## Others

- Add debug logging about subscription to trace which subscriptions are subscribed.
